### PR TITLE
Closes #43 | Add id_panl_bppt dataset loader

### DIFF
--- a/nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py
+++ b/nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Tuple, TypedDict, Literal
+from typing import Dict, List, Literal, Tuple, TypedDict
 
 import datasets
 
@@ -48,12 +48,7 @@ class IdPanlBppt(datasets.GeneratorBasedBuilder):
         # seems to be the number of words in the file
         words: Literal["150K", "100K"]
 
-    TOPICS: List[Topic] = [
-        {"name": "Economy", "words": "150K"},
-        {"name": "International", "words": "150K"},
-        {"name": "Science", "words": "100K"},
-        {"name": "Sport", "words": "100K"}
-    ]
+    TOPICS: List[Topic] = [{"name": "Economy", "words": "150K"}, {"name": "International", "words": "150K"}, {"name": "Science", "words": "100K"}, {"name": "Sport", "words": "100K"}]
 
     SOURCE_LANGUAGE = "en"
     TARGET_LANGUAGE = "id"
@@ -117,9 +112,7 @@ class IdPanlBppt(datasets.GeneratorBasedBuilder):
         for topic in self.TOPICS:
             src_path = f"PANL-BPPT-{topic['name'][:3].upper()}-{self.SOURCE_LANGUAGE.upper()}-{topic['words']}w.txt"
             tgt_path = f"PANL-BPPT-{topic['name'][:3].upper()}-{self.TARGET_LANGUAGE.upper()}-{topic['words']}w.txt"
-            with open(os.path.join(dir, src_path), encoding="utf-8") as f1, open(
-                os.path.join(dir, tgt_path), encoding="utf-8"
-            ) as f2:
+            with open(os.path.join(dir, src_path), encoding="utf-8") as f1, open(os.path.join(dir, tgt_path), encoding="utf-8") as f2:
                 src = f1.read().split("\n")[:-1]
                 tgt = f2.read().split("\n")[:-1]
                 for s, t in zip(src, tgt):

--- a/nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py
+++ b/nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py
@@ -1,0 +1,142 @@
+import os
+from typing import Dict, List, Tuple, TypedDict, Literal
+
+import datasets
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks
+
+_CITATION = """\
+@inproceedings{id_panl_bppt,
+  author    = {PAN Localization - BPPT},
+  title     = {Parallel Text Corpora, English Indonesian},
+  year      = {2009},
+  url       = {http://digilib.bppt.go.id/sampul/p92-budiono.pdf},
+}
+"""
+
+_DATASETNAME = "id_panl_bppt"
+_DESCRIPTION = """\
+Parallel Text Corpora for Multi-Domain Translation System created by BPPT (Indonesian Agency for the Assessment and
+Application of Technology) for PAN Localization Project (A Regional Initiative to Develop Local Language Computing
+Capacity in Asia). The dataset contains about 24K sentences in English and Bahasa Indonesia from 4 different topics
+(Economy, International Affairs, Science & Technology, and Sports).
+"""
+_HOMEPAGE = "http://digilib.bppt.go.id/sampul/p92-budiono.pdf"
+_LICENSE = ""
+_URLS = {
+    _DATASETNAME: "https://github.com/cahya-wirawan/indonesian-language-models/raw/master/data/BPPTIndToEngCorpusHalfM.zip",
+}
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+# Source has no versioning
+_SOURCE_VERSION = "1.0.0"
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class IdPanlBppt(datasets.GeneratorBasedBuilder):
+    """\
+    Dataset contains about ~24K sentences in English and Bahasa Indonesia from 4 different topics (Economy,
+    International Affairs, Science & Technology, and Sports)
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+
+    class Topic(TypedDict):
+        name: Literal["Economy", "International", "Science", "Sport"]
+        # seems to be the number of words in the file
+        words: Literal["150K", "100K"]
+
+    TOPICS: List[Topic] = [
+        {"name": "Economy", "words": "150K"},
+        {"name": "International", "words": "150K"},
+        {"name": "Science", "words": "100K"},
+        {"name": "Sport", "words": "100K"}
+    ]
+
+    SOURCE_LANGUAGE = "en"
+    TARGET_LANGUAGE = "id"
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="id_panl_bppt_source",
+            version=SOURCE_VERSION,
+            description="PANL BPPT source schema",
+            schema="source",
+            subset_id="id_panl_bppt",
+        ),
+        NusantaraConfig(
+            name="id_panl_bppt_nusantara_t2t",
+            version=NUSANTARA_VERSION,
+            description="PANL BPPT Nusantara schema",
+            schema="nusantara_t2t",
+            subset_id="id_panl_bppt",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "id_panl_bppt_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "translation": datasets.features.Translation(languages=[self.SOURCE_LANGUAGE, self.TARGET_LANGUAGE]),
+                    "topic": datasets.features.ClassLabel(names=list(map(lambda topic: topic["name"], self.TOPICS))),
+                }
+            )
+        elif self.config.schema == "nusantara_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "dir": os.path.join(data_dir, "plain"),
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, dir: str, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        id = 0
+        for topic in self.TOPICS:
+            src_path = f"PANL-BPPT-{topic['name'][:3].upper()}-{self.SOURCE_LANGUAGE.upper()}-{topic['words']}w.txt"
+            tgt_path = f"PANL-BPPT-{topic['name'][:3].upper()}-{self.TARGET_LANGUAGE.upper()}-{topic['words']}w.txt"
+            with open(os.path.join(dir, src_path), encoding="utf-8") as f1, open(
+                os.path.join(dir, tgt_path), encoding="utf-8"
+            ) as f2:
+                src = f1.read().split("\n")[:-1]
+                tgt = f2.read().split("\n")[:-1]
+                for s, t in zip(src, tgt):
+                    if self.config.schema == "source":
+                        yield id, {
+                            "id": str(id),
+                            "translation": {self.SOURCE_LANGUAGE: s, self.TARGET_LANGUAGE: t},
+                            "topic": topic["name"],
+                        }
+                    elif self.config.schema == "nusantara_t2t":
+                        # Schema does not have topics or any other fields to have the topics
+                        yield id, {
+                            "id": str(id),
+                            "text_1": s,
+                            "text_2": t,
+                            "text_1_name": self.SOURCE_LANGUAGE,
+                            "text_2_name": self.TARGET_LANGUAGE,
+                        }
+
+                    id += 1


### PR DESCRIPTION
### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

# Tests
## tests.test_nusantara
```
python3.8 -m tests.test_nusantara nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py
INFO:__main__:args: Namespace(data_dir=None, path='nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py', schema=None, subset_id=None, use_auth_token=None)
INFO:__main__:self.PATH: nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py
INFO:__main__:self.SUBSET_ID: id_panl_bppt
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module nusantara.nusa_datasets.id_panl_bppt.id_panl_bppt
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.MACHINE_TRANSLATION: 'MT'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'T2T'}
INFO:__main__:schemas_to_check: {'T2T'}
INFO:__main__:Checking load_dataset with config name id_panl_bppt_source
Downloading and preparing dataset id_panl_bppt/id_panl_bppt_source to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_source/1.0.0/5f0b14d46f49e288b23327169cd009dddca571eae014c7e13006acffdb34da70...
Dataset id_panl_bppt downloaded and prepared to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_source/1.0.0/5f0b14d46f49e288b23327169cd009dddca571eae014c7e13006acffdb34da70. Subsequent calls will reuse this data.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 413.39it/s]
INFO:__main__:Checking load_dataset with config name id_panl_bppt_nusantara_t2t
Downloading and preparing dataset id_panl_bppt/id_panl_bppt_nusantara_t2t to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_nusantara_t2t/1.0.0/5f0b14d46f49e288b23327169cd009dddca571eae014c7e13006acffdb34da70...
Dataset id_panl_bppt downloaded and prepared to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_nusantara_t2t/1.0.0/5f0b14d46f49e288b23327169cd009dddca571eae014c7e13006acffdb34da70. Subsequent calls will reuse this data.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 579.72it/s]
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 24021 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 24021
text_1: 24021
text_2: 24021
text_1_name: 24021
text_2_name: 24021

.
----------------------------------------------------------------------
Ran 1 test in 5.276s

OK
```

## load_dataset
```
>>> import datasets
>>> x = datasets.load_dataset("nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py", name="id_panl_bppt_source")
Downloading and preparing dataset id_panl_bppt/id_panl_bppt_source to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_source/1.0.0/0924703c78a598dfaab6895474eb5a492a3a10c5fb661eef01ff29e6fca6a570...
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.37M/2.37M [00:00<00:00, 18.8MB/s]
Dataset id_panl_bppt downloaded and prepared to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_source/1.0.0/0924703c78a598dfaab6895474eb5a492a3a10c5fb661eef01ff29e6fca6a570. Subsequent calls will reuse this data.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 98.03it/s]
>>> x['train'].to_pandas()
          id                                        translation  topic
0          0  {'en': 'Minister of Finance Sri Mulyani Indraw...      0
1          1  {'en': 'In a press briefing held at the minist...      0
2          2  {'en': 'Sri Mulayani showed other factors, amo...      0
3          3  {'en': 'This also happened to fuel oil prices....      0
4          4  {'en': 'The 2007 state budget is so far in a g...      0
...      ...                                                ...    ...
24016  24016  {'en': 'Former Dutch international Koeman sign...      3
24017  24017  {'en': 'Valencia were then fourth in the table...      3
24018  24018  {'en': 'Spanish media also reported on Monday ...      3
24019  24019  {'en': 'The reports said club delegate Salvado...      3
24020  24020  {'en': 'Koeman has appeared an increasingly is...      3

[24021 rows x 3 columns]
>>> x = datasets.load_dataset("nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py", name="id_panl_bppt_nusantara_t2t")
Downloading and preparing dataset id_panl_bppt/id_panl_bppt_nusantara_t2t to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_nusantara_t2t/1.0.0/0924703c78a598dfaab6895474eb5a492a3a10c5fb661eef01ff29e6fca6a570...
>>> x = datasets.load_dataset("nusantara/nusa_datasets/id_panl_bppt/id_panl_bppt.py", name="id_panl_bppt_nusantara_t2t")
Downloading and preparing dataset id_panl_bppt/id_panl_bppt_nusantara_t2t to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_nusantara_t2t/1.0.0/6489a211b6af5f9fd78ae3dec0a295da5dfb0245f1a1d76c46005b44a8668bc1...
Dataset id_panl_bppt downloaded and prepared to /Users/jamesjaya/.cache/huggingface/datasets/id_panl_bppt/id_panl_bppt_nusantara_t2t/1.0.0/6489a211b6af5f9fd78ae3dec0a295da5dfb0245f1a1d76c46005b44a8668bc1. Subsequent calls will reuse this data.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 494.32it/s]
>>> x['train'].to_pandas()
          id                                             text_1                                             text_2 text_1_name text_2_name
0          0  Minister of Finance Sri Mulyani Indrawati said...  Menteri Keuangan Sri Mulyani mengatakan koreks...          en          id
1          1  In a press briefing held at the ministry here ...  Dalam jumpa pers bersama Dirut Bursa Efek Jaka...          en          id
2          2  Sri Mulayani showed other factors, among other...  Kita melihat faktor inflasi dari makanan akan ...          en          id
3          3             This also happened to fuel oil prices.                 Demikian pula dengan harga minyak.          en          id
4          4  The 2007 state budget is so far in a good cond...  Kondisi APBN 2007 pada dua pekan awal, secara ...          en          id
...      ...                                                ...                                                ...         ...         ...
24016  24016  Former Dutch international Koeman signed a two...  Mantan pemain internasional Belanda, Koeman, m...          en          id
24017  24017  Valencia were then fourth in the table, four p...  Valencia kemudian beradadi urutan keempat pada...          en          id
24018  24018  Spanish media also reported on Monday the club...  Media Spanyol pada Senin juga melaporkan bahwa...          en          id
24019  24019  The reports said club delegate Salvador Gonzal...  Laporan tersebut menyebutkan delegasi klub Sal...          en          id
24020  24020  Koeman has appeared an increasingly isolated f...  Koeman menjadi figur yang semakin terasing di ...          en          id

[24021 rows x 5 columns]
```
