### PR TITLE
fix typo in requirements.txt

### DIFF
--- a/.github/workflows/selfassign.yml
+++ b/.github/workflows/selfassign.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       (github.event.comment.body == '#take' ||
-       github.event.comment.body == '#self-assign')
+       github.event.comment.body == '#self-assign') &&
+       (!github.event.issue.pull_request)
     steps:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ black~=22.0
 flake8>=3.8.3
 isort>=5.0.0
 aiohttp==3.8.1
-pre-commit=2.19.0
+pre-commit==2.19.0


### PR DESCRIPTION
additional prevent github actions from running if the comment issued comes from PR and not issue.
Ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only