### PR TITLE
add multilabel text classification schema

### DIFF
--- a/nusantara/utils/schemas/__init__.py
+++ b/nusantara/utils/schemas/__init__.py
@@ -2,7 +2,8 @@ from .kb import features as kb_features
 from .pairs import features as pairs_features
 from .qa import features as qa_features
 from .text import features as text_features
+from .text_multilabel import features as text_multi_features
 from .text_to_text import features as text2text_features
 from .seq_label import features as seq_label_features
 
-__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "pairs_features", "seq_label_features"]
+__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "seq_label_features"]

--- a/nusantara/utils/schemas/text_multilabel.py
+++ b/nusantara/utils/schemas/text_multilabel.py
@@ -1,0 +1,14 @@
+"""
+General Text Classification Schema
+"""
+import datasets
+
+def features(label_names = ["Yes", "No"]):
+    return datasets.Features(
+        {
+            "id": datasets.Value("string"),
+            "text": datasets.Value("string"),
+            "labels": [datasets.ClassLabel(names=label_names)],
+        }
+    )
+

--- a/tests/test_nusantara.py
+++ b/tests/test_nusantara.py
@@ -12,7 +12,7 @@ from typing import Iterable, Iterator, List, Optional, Union, Dict
 import datasets
 from datasets import DatasetDict, Features
 from nusantara.utils.constants import Tasks
-from nusantara.utils.schemas import kb_features, pairs_features, qa_features, text2text_features, text_features, seq_label_features
+from nusantara.utils.schemas import kb_features, pairs_features, qa_features, text2text_features, text_features, text_multi_features, seq_label_features
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -36,7 +36,7 @@ _TASK_TO_SCHEMA = {
     Tasks.MACHINE_TRANSLATION: "T2T",
     Tasks.SUMMARIZATION: "T2T",
     Tasks.SENTIMENT_ANALYSIS: "TEXT",
-    Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS: "TEXT",
+    Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS: "TEXT_MULTI",
     Tasks.EMOTION_CLASSIFICATION: "TEXT",
     Tasks.SELF_SUPERVISED_PRETRAINING: "TEXT",
 }
@@ -49,6 +49,7 @@ _SCHEMA_TO_FEATURES = {
     "QA": qa_features,
     "T2T": text2text_features,
     "TEXT": text_features(),
+    "TEXT_MULTI": text_multi_features(),
     "PAIRS": pairs_features(),
     "SEQ_LABEL": seq_label_features(),
 }
@@ -189,7 +190,17 @@ class TestDataLoader(unittest.TestCase):
                 data_dir=self.DATA_DIR,
                 use_auth_token=self.USE_AUTH_TOKEN,
             )
-            logger.info(f"Dataset sample\n{self.datasets_nusantara[schema]['train'][0]}")
+        
+        # check dataset samples
+        for schema in ['source'] + [f"nusantara_{s.lower()}" for s in self.schemas_to_check]:
+            dataset = datasets.load_dataset(
+                self.PATH,
+                name=f"{self.SUBSET_ID}_{schema}",
+                data_dir=self.DATA_DIR,
+                use_auth_token=self.USE_AUTH_TOKEN,
+            )
+            logger.info(f"Dataset sample [{schema}]\n{dataset['train'][0]}")
+        
 
     def get_feature_statistics(self, features: Features, schema: str) -> Dict:
         """


### PR DESCRIPTION
Also fix id_multilabel_hs to follow this schema.

The current dataset format:
- with source schema
```
{'tweet': "- disaat semua cowok berusaha melacak perhatian gue. loe lantas remehkan perhatian yg gue kasih khusus ke elo. basic elo cowok bego ! ! !'", 'HS': True, 'Abusive': True, 'HS_Individual': True, 'HS_Group': False, 'HS_Religion': False, 'HS_Race': False, 'HS_Physical': False, 'HS_Gender': False, 'HS_Other': True, 'HS_Weak': True, 'HS_Moderate': False, 'HS_Strong': False}
```
- with nusantara schema
```
{'id': '0', 'text': "- disaat semua cowok berusaha melacak perhatian gue. loe lantas remehkan perhatian yg gue kasih khusus ke elo. basic elo cowok bego ! ! !'", 'labels': [1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0]}
```

Also modify test script to print the dataset sample as well.