### PR TITLE
Add self-supervised pretraining (SSP) schema

### DIFF
--- a/nusantara/utils/schemas/__init__.py
+++ b/nusantara/utils/schemas/__init__.py
@@ -5,5 +5,6 @@ from .text import features as text_features
 from .text_multilabel import features as text_multi_features
 from .text_to_text import features as text2text_features
 from .seq_label import features as seq_label_features
+from .self_supervised_pretraining import features as ssp_features
 
-__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "seq_label_features"]
+__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "seq_label_features", "ssp_features"]

--- a/nusantara/utils/schemas/self_supervised_pretraining.py
+++ b/nusantara/utils/schemas/self_supervised_pretraining.py
@@ -1,0 +1,11 @@
+"""
+Self-supervised Pretraining (SSP) Classification Schema
+"""
+import datasets
+
+features = datasets.Features(
+    {
+        "id": datasets.Value("string"),
+        "text": datasets.Value("string"),
+    }
+)

--- a/task_schemas.md
+++ b/task_schemas.md
@@ -299,3 +299,14 @@ Passages capture document structure, such as the title and abstact sections of a
     ]
 }
 ```
+
+## Self-supervised pretraining
+- [Schema Template](nusantara/utils/schemas/self_supervised_pretraining.py)
+- Examples: [CC100] (nusantara/nusa_datasets/cc100/cc100.py)
+
+```
+{
+    "id": "0",
+    "text": "Placeholder text. Will change to a real example soon."
+}
+```

--- a/tests/test_nusantara.py
+++ b/tests/test_nusantara.py
@@ -12,7 +12,7 @@ from typing import Iterable, Iterator, List, Optional, Union, Dict
 import datasets
 from datasets import DatasetDict, Features
 from nusantara.utils.constants import Tasks
-from nusantara.utils.schemas import kb_features, pairs_features, qa_features, text2text_features, text_features, text_multi_features, seq_label_features
+from nusantara.utils.schemas import kb_features, pairs_features, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -39,7 +39,7 @@ _TASK_TO_SCHEMA = {
     Tasks.SENTIMENT_ANALYSIS: "TEXT",
     Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS: "TEXT_MULTI",
     Tasks.EMOTION_CLASSIFICATION: "TEXT",
-    Tasks.SELF_SUPERVISED_PRETRAINING: "TEXT",
+    Tasks.SELF_SUPERVISED_PRETRAINING: "SSP",
 }
 
 _VALID_TASKS = set(_TASK_TO_SCHEMA.keys())
@@ -53,6 +53,7 @@ _SCHEMA_TO_FEATURES = {
     "TEXT_MULTI": text_multi_features(),
     "PAIRS": pairs_features(),
     "SEQ_LABEL": seq_label_features(),
+    "SSP": ssp_features,
 }
 
 _TASK_TO_FEATURES = {


### PR DESCRIPTION
Example dataset that uses this schema: CC-100.
Schema features consist of `id` and `text`.