### PR TITLE
 Closes #21 | Add news_en_id MT DataLoader

### DIFF
--- a/nusantara/nusa_datasets/news_en_id/news_en_id.py
+++ b/nusantara/nusa_datasets/news_en_id/news_en_id.py
@@ -15,29 +15,20 @@ _UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
 _LANGUAGES = ["ind", "eng"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
 _LOCAL = False
 _CITATION = """\
-@inproceedings{cahyawijaya-etal-2021-indonlg,
-    title = "{I}ndo{NLG}: Benchmark and Resources for Evaluating {I}ndonesian Natural Language Generation",
-    author = "Cahyawijaya, Samuel  and
-      Winata, Genta Indra  and
-      Wilie, Bryan  and
-      Vincentio, Karissa  and
-      Li, Xiaohong  and
-      Kuncoro, Adhiguna  and
-      Ruder, Sebastian  and
-      Lim, Zhi Yuan  and
-      Bahar, Syafri  and
-      Khodra, Masayu  and
-      Purwarianti, Ayu  and
-      Fung, Pascale",
-    booktitle = "Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing",
-    month = nov,
-    year = "2021",
-    address = "Online and Punta Cana, Dominican Republic",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/2021.emnlp-main.699",
-    doi = "10.18653/v1/2021.emnlp-main.699",
-    pages = "8875--8898",
-    abstract = "Natural language generation (NLG) benchmarks provide an important avenue to measure progress and develop better NLG systems. Unfortunately, the lack of publicly available NLG benchmarks for low-resource languages poses a challenging barrier for building NLG systems that work well for languages with limited amounts of data. Here we introduce IndoNLG, the first benchmark to measure natural language generation (NLG) progress in three low-resource{---}yet widely spoken{---}languages of Indonesia: Indonesian, Javanese, and Sundanese. Altogether, these languages are spoken by more than 100 million native speakers, and hence constitute an important use case of NLG systems today. Concretely, IndoNLG covers six tasks: summarization, question answering, chit-chat, and three different pairs of machine translation (MT) tasks. We collate a clean pretraining corpus of Indonesian, Sundanese, and Javanese datasets, Indo4B-Plus, which is used to pretrain our models: IndoBART and IndoGPT. We show that IndoBART and IndoGPT achieve competitive performance on all tasks{---}despite using only one-fifth the parameters of a larger multilingual model, mBART-large (Liu et al., 2020). This finding emphasizes the importance of pretraining on closely related, localized languages to achieve more efficient learning and faster inference at very low-resource languages like Javanese and Sundanese.",
+@inproceedings{guntara-etal-2020-benchmarking,
+    title = "Benchmarking Multidomain {E}nglish-{I}ndonesian Machine Translation",
+    author = "Guntara, Tri Wahyu  and
+      Aji, Alham Fikri  and
+      Prasojo, Radityo Eko",
+    booktitle = "Proceedings of the 13th Workshop on Building and Using Comparable Corpora",
+    month = may,
+    year = "2020",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://aclanthology.org/2020.bucc-1.6",
+    pages = "35--43",
+    language = "English",
+    ISBN = "979-10-95546-42-9",
 }
 """
 
@@ -45,7 +36,7 @@ _DESCRIPTION = """\
 News En-Id is a machine translation dataset containing Indonesian-English parallel sentences collected from the news. The news dataset is collected from multiple sources: Pan Asia Networking Localization (PANL), Bilingual BBC news articles, Berita Jakarta, and GlobalVoices. We split the dataset and use 75% as the training set, 10% as the validation set, and 15% as the test set. Each of the datasets is evaluated in both directions, i.e., English to Indonesian (En → Id) and Indonesian to English (Id → En) translations.
 """
 
-_HOMEPAGE = "https://github.com/IndoNLP/indonlg"
+_HOMEPAGE = "https://github.com/gunnxx/indonesian-mt-data"
 
 _LICENSE = "Creative Common Attribution Share-Alike 4.0 International"
 

--- a/nusantara/nusa_datasets/news_en_id/news_en_id.py
+++ b/nusantara/nusa_datasets/news_en_id/news_en_id.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+from typing import List
+
+import datasets
+import json
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks, DEFAULT_SOURCE_VIEW_NAME, DEFAULT_NUSANTARA_VIEW_NAME
+
+_DATASETNAME = "news_en_id"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
+
+_LANGUAGES = ["ind", "eng"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+_LOCAL = False
+_CITATION = """\
+@inproceedings{cahyawijaya-etal-2021-indonlg,
+    title = "{I}ndo{NLG}: Benchmark and Resources for Evaluating {I}ndonesian Natural Language Generation",
+    author = "Cahyawijaya, Samuel  and
+      Winata, Genta Indra  and
+      Wilie, Bryan  and
+      Vincentio, Karissa  and
+      Li, Xiaohong  and
+      Kuncoro, Adhiguna  and
+      Ruder, Sebastian  and
+      Lim, Zhi Yuan  and
+      Bahar, Syafri  and
+      Khodra, Masayu  and
+      Purwarianti, Ayu  and
+      Fung, Pascale",
+    booktitle = "Proceedings of the 2021 Conference on Empirical Methods in Natural Language Processing",
+    month = nov,
+    year = "2021",
+    address = "Online and Punta Cana, Dominican Republic",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2021.emnlp-main.699",
+    doi = "10.18653/v1/2021.emnlp-main.699",
+    pages = "8875--8898",
+    abstract = "Natural language generation (NLG) benchmarks provide an important avenue to measure progress and develop better NLG systems. Unfortunately, the lack of publicly available NLG benchmarks for low-resource languages poses a challenging barrier for building NLG systems that work well for languages with limited amounts of data. Here we introduce IndoNLG, the first benchmark to measure natural language generation (NLG) progress in three low-resource{---}yet widely spoken{---}languages of Indonesia: Indonesian, Javanese, and Sundanese. Altogether, these languages are spoken by more than 100 million native speakers, and hence constitute an important use case of NLG systems today. Concretely, IndoNLG covers six tasks: summarization, question answering, chit-chat, and three different pairs of machine translation (MT) tasks. We collate a clean pretraining corpus of Indonesian, Sundanese, and Javanese datasets, Indo4B-Plus, which is used to pretrain our models: IndoBART and IndoGPT. We show that IndoBART and IndoGPT achieve competitive performance on all tasks{---}despite using only one-fifth the parameters of a larger multilingual model, mBART-large (Liu et al., 2020). This finding emphasizes the importance of pretraining on closely related, localized languages to achieve more efficient learning and faster inference at very low-resource languages like Javanese and Sundanese.",
+}
+"""
+
+_DESCRIPTION = """\
+News En-Id is a machine translation dataset containing Indonesian-English parallel sentences collected from the news. The news dataset is collected from multiple sources: Pan Asia Networking Localization (PANL), Bilingual BBC news articles, Berita Jakarta, and GlobalVoices. We split the dataset and use 75% as the training set, 10% as the validation set, and 15% as the test set. Each of the datasets is evaluated in both directions, i.e., English to Indonesian (En → Id) and Indonesian to English (Id → En) translations.
+"""
+
+_HOMEPAGE = "https://github.com/IndoNLP/indonlg"
+
+_LICENSE = "Creative Common Attribution Share-Alike 4.0 International"
+
+_URLs = {"indonlg": "https://storage.googleapis.com/babert-pretraining/IndoNLG_finals/downstream_task/downstream_task_datasets.zip"}
+
+_SUPPORTED_TASKS = [Tasks.MACHINE_TRANSLATION]
+
+_SOURCE_VERSION = "1.0.0"
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class NewsEnId(datasets.GeneratorBasedBuilder):
+    """Bible Su-Id is a machine translation dataset containing Indonesian-Sundanese parallel sentences collected from the bible.."""
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="news_en_id_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description="News En-Id source schema",
+            schema="source",
+            subset_id="news_en_id",
+        ),
+        NusantaraConfig(
+            name="news_en_id_nusantara_t2t",
+            version=datasets.Version(_NUSANTARA_VERSION),
+            description="News En-Id Nusantara schema",
+            schema="nusantara_t2t",
+            subset_id="news_en_id",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "news_en_id_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features({"id": datasets.Value("string"), "text": datasets.Value("string"), "label": datasets.Value("string")})
+        elif self.config.schema == "nusantara_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        base_path = Path(dl_manager.download_and_extract(_URLs["indonlg"])) / "IndoNLG_downstream_tasks" / "MT_IMD_NEWS"
+        data_files = {
+            "train": base_path / "train_preprocess.json",
+            "validation": base_path / "valid_preprocess.json",
+            "test": base_path / "test_preprocess.json",
+        }
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": data_files["train"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": data_files["validation"]},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": data_files["test"]},
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path):
+        data = json.load(open(filepath, "r"))
+        if self.config.schema == "source":
+            for row in data:
+                ex = {"id": row["id"], "text": row["text"], "label": row["label"]}
+                yield row["id"], ex
+        elif self.config.schema == "nusantara_t2t":
+            for row in data:
+                ex = {
+                    "id": row["id"],
+                    "text_1": row["text"],
+                    "text_2": row["label"],
+                    "text_1_name": "eng",
+                    "text_2_name": "ind",
+                }
+                yield row["id"], ex
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

## tests.test_nusantara
```
python -m tests.test_nusantara nusantara/nusa_datasets/news_en_id/news_en_id.py
INFO:__main__:args: Namespace(data_dir=None, path='nusantara/nusa_datasets/news_en_id/news_en_id.py', schema=None, subset_id=None, use_auth_token=None)
INFO:__main__:self.PATH: nusantara/nusa_datasets/news_en_id/news_en_id.py
INFO:__main__:self.SUBSET_ID: news_en_id
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module nusantara.nusa_datasets.news_en_id.news_en_id
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.MACHINE_TRANSLATION: 'MT'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'T2T'}
INFO:__main__:schemas_to_check: {'T2T'}
INFO:__main__:Checking load_dataset with config name news_en_id_source
Downloading and preparing dataset news_en_id/news_en_id_source to C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_source\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f...
Dataset news_en_id downloaded and prepared to C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_source\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f. Subsequent calls will reuse this data.
100%|███████████████████████████████████████████████| 3/3 [00:00<00:00, 55.49it/s]
INFO:__main__:Checking load_dataset with config name news_en_id_nusantara_t2t      
Downloading and preparing dataset news_en_id/news_en_id_nusantara_t2t to C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_nusantara_t2t\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f...
Dataset news_en_id downloaded and prepared to C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_nusantara_t2t\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f. Subsequent calls will reuse this data.
100%|███████████████████████████████████████████████| 3/3 [00:00<00:00, 65.22it/s] 
WARNING:datasets.builder:Reusing dataset news_en_id (C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_source\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f)
100%|██████████████████████████████████████████████| 3/3 [00:00<00:00, 333.45it/s]
INFO:__main__:Dataset sample [source]
{'id': 'news_train_0', 'text': '"Southeast Asia: The shoe, the shoe · Global Voices"\n', 'label': '"Asia Tenggara: Sepatu, Oh Sepatu"\n'}
WARNING:datasets.builder:Reusing dataset news_en_id (C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_nusantara_t2t\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f)
100%|██████████████████████████████████████████████| 3/3 [00:00<00:00, 428.44it/s]
INFO:__main__:Dataset sample [nusantara_t2t]
{'id': 'news_train_0', 'text_1': '"Southeast Asia: The shoe, the shoe · Global Voices"\n', 'text_2': '"Asia Tenggara: Sepatu, Oh Sepatu"\n', 'text_1_name': 'eng', 'text_2_name': 'ind'}
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 1954 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 38462
text_1: 38462
text_2: 38462
text_1_name: 38462
text_2_name: 38462

validation
==========
id: 1953
text_1: 1953
text_2: 1953
text_1_name: 1953
text_2_name: 1953

test
==========
id: 1954
text_1: 1954
text_2: 1954
text_1_name: 1954
text_2_name: 1954

.
----------------------------------------------------------------------
Ran 1 test in 17.887s

OK
```

## Load Dataset
```
Python 3.8.8 (default, Apr 13 2021, 15:08:03) [MSC v.1916 64 bit (AMD64)] :: Anaconda, Inc. on win32

Warning:
This Python interpreter is in a conda environment, but the environment has
not been activated.  Libraries may fail to load.  To activate this environment     
please see https://conda.io/activation

Type "help", "copyright", "credits" or "license" for more information.
>>> from datasets import load_dataset
>>> data = load_dataset("nusantara/nusa_datasets/news_en_id/news_en_id.py", name="news_en_id_source")
Reusing dataset news_en_id (C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_source\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f)
100%|██████████████████████████████████████████████| 3/3 [00:00<00:00, 319.96it/s]
>>> data['train'].to_pandas()
	id	text	label
0	news_train_0	"Southeast Asia: The shoe, the shoe · Global V...	"Asia Tenggara: Sepatu, Oh Sepatu"\n
1	news_train_1	Iraqi journalist Muntadar al-Zaidi will be kno...	Jurnalis Irak Muntadar al-Zaidi akan lama dike...
2	news_train_2	He who succeeded in throwing a pair of shoes a...	Dia telah sukses melempar sepasang sepatu kepa...
3	news_train_3	The shoes are now priceless.\n	Sepasang sepatu tersebut kini amat berharga.\n
4	news_train_4	A Saudi entrepreneur has offered $10 million f...	Seorang pengusaha Arab Saudi menawarkan 10 jut...
...	...	...	...
38457	news_train_38464	Maliki arrived Wednesday from Japan for a thre...	Maliki tiba dari lawatan selama tiga hari ke J...
38458	news_train_38465	The Australian government has consistently sup...	Pemerintah Australia terus-menerus mendukung u...
38459	news_train_38466	The act makes him/her must be sent to court, w...	Perbuatannya ini membuatnya berurusan dengan h...
38460	news_train_38467	In the same area last month, militants decapit...	Di daerah yang sama bulan lalu, gerilyawan mem...
38461	news_train_38468	Smoking harms people's health, but restraining...	Merokok merusak kesehatan masyarakat, namun me...
38462 rows × 3 columns
>>> data['validation'].to_pandas()
	id	text	label
0	news_valid_0	"We also know that tobacco sponsorship of spor...	"Kita juga tahu bahwa sponsor pabrik rokok kep...
1	news_valid_1	The test is classified," he told.\n	Sifatnya rahasia semua," ujarnya.\n
2	news_valid_2	The Saudi officials say any women qualifying f...	Para pejabat Saudi mengatakan atlet putri yang...
3	news_valid_3	Aside from our own officers, we will also be i...	Selain petugas kami berkeliling taman, kami ju...
4	news_valid_4	"The water which flooded our residential area ...	"Air yang menggenangi pemukiman kami merupakan...
...	...	...	...
1948	news_valid_1948	"By utilizing better structures and facilities...	"Dengan sarana, dan fasilitas yang lebih baik ...
1949	news_valid_1949	It was predicted that until the end of Decembe...	Bahkan, diperkirakan hingga akhir Desember mas...
1950	news_valid_1950	The revitalized buses also have middle doors a...	Lalu ada pintu tengah untuk naik ke halte.\n
1951	news_valid_1951	"This plan will be enforced when it is impleme...	"Nanti akan dipaksa, bukan hanya diimbau.\n
1952	news_valid_1952	Thus, we rushed to leave the house and take re...	Makanya langsung buru-buru keluar rumah dan me...
1953 rows × 3 columns
>>> data['test'].to_pandas()
	id	text	label
0	news_test_0	According to him, this situation is caused by ...	Menurut Hilman, sepinya penumpang karena banya...
1	news_test_1	Amnesty says that to prop up their finances, l...	Amnesty mengatakan untuk meningkatkan anggaran...
2	news_test_2	There have been objections from oil and natura...	Perusahaan gas dan juga industri ikan mengajuk...
3	news_test_3	A researcher in Denmark has discovered a previ...	Seorang peneliti di Denmark menemukan dongeng ...
4	news_test_4	The BBC Washington correspondent says the Supr...	Wartawan BBC di Washington mengatakan MA tampa...
...	...	...	...
1949	news_test_1949	The latest global assessment of threatened pla...	Penelitian global terbaru tentang spesies tumb...
1950	news_test_1950	Prisoner have escaped from a jail\n	Tahanan lari dari penjara\n
1951	news_test_1951	Australia considers new 'slavery' law\n	Australia pertimbangan UU baru 'perbudakan'\n
1952	news_test_1952	Experts on international aid say financial sup...	Para ahli bantuan internasional mengatakan duk...
1953	news_test_1953	But its percentage is almost the same," he fin...	Tapi persentasenya hampir sama," tandasnya.\n
1954 rows × 3 columns
>>> data = load_dataset("nusantara/nusa_datasets/news_en_id/news_en_id.py", name="news_en_id_source")
>>> data = load_dataset("nusantara/nusa_datasets/news_en_id/news_en_id.py", name="news_en_id_nusantara_t2t")
Reusing dataset news_en_id (C:\Users\HP\.cache\huggingface\datasets\news_en_id\news_en_id_nusantara_t2t\1.0.0\af0108540f9dae2cf6abcf0e8c9f9084970dc6a3d8aaac87275424792b7abe6f)
100%|██████████████████████████████████████████████| 3/3 [00:00<00:00, 185.66it/s]
>>> data['train'].to_pandas()
	id	text_1	text_2	text_1_name	text_2_name
0	news_train_0	"Southeast Asia: The shoe, the shoe · Global V...	"Asia Tenggara: Sepatu, Oh Sepatu"\n	eng	ind
1	news_train_1	Iraqi journalist Muntadar al-Zaidi will be kno...	Jurnalis Irak Muntadar al-Zaidi akan lama dike...	eng	ind
2	news_train_2	He who succeeded in throwing a pair of shoes a...	Dia telah sukses melempar sepasang sepatu kepa...	eng	ind
3	news_train_3	The shoes are now priceless.\n	Sepasang sepatu tersebut kini amat berharga.\n	eng	ind
4	news_train_4	A Saudi entrepreneur has offered $10 million f...	Seorang pengusaha Arab Saudi menawarkan 10 jut...	eng	ind
...	...	...	...	...	...
38457	news_train_38464	Maliki arrived Wednesday from Japan for a thre...	Maliki tiba dari lawatan selama tiga hari ke J...	eng	ind
38458	news_train_38465	The Australian government has consistently sup...	Pemerintah Australia terus-menerus mendukung u...	eng	ind
38459	news_train_38466	The act makes him/her must be sent to court, w...	Perbuatannya ini membuatnya berurusan dengan h...	eng	ind
38460	news_train_38467	In the same area last month, militants decapit...	Di daerah yang sama bulan lalu, gerilyawan mem...	eng	ind
38461	news_train_38468	Smoking harms people's health, but restraining...	Merokok merusak kesehatan masyarakat, namun me...	eng	ind
38462 rows × 5 columns
>>> data['validation'].to_pandas()
	id	text_1	text_2	text_1_name	text_2_name
0	news_valid_0	"We also know that tobacco sponsorship of spor...	"Kita juga tahu bahwa sponsor pabrik rokok kep...	eng	ind
1	news_valid_1	The test is classified," he told.\n	Sifatnya rahasia semua," ujarnya.\n	eng	ind
2	news_valid_2	The Saudi officials say any women qualifying f...	Para pejabat Saudi mengatakan atlet putri yang...	eng	ind
3	news_valid_3	Aside from our own officers, we will also be i...	Selain petugas kami berkeliling taman, kami ju...	eng	ind
4	news_valid_4	"The water which flooded our residential area ...	"Air yang menggenangi pemukiman kami merupakan...	eng	ind
...	...	...	...	...	...
1948	news_valid_1948	"By utilizing better structures and facilities...	"Dengan sarana, dan fasilitas yang lebih baik ...	eng	ind
1949	news_valid_1949	It was predicted that until the end of Decembe...	Bahkan, diperkirakan hingga akhir Desember mas...	eng	ind
1950	news_valid_1950	The revitalized buses also have middle doors a...	Lalu ada pintu tengah untuk naik ke halte.\n	eng	ind
1951	news_valid_1951	"This plan will be enforced when it is impleme...	"Nanti akan dipaksa, bukan hanya diimbau.\n	eng	ind
1952	news_valid_1952	Thus, we rushed to leave the house and take re...	Makanya langsung buru-buru keluar rumah dan me...	eng	ind
1953 rows × 5 columns
>>> data['test'].to_pandas()
	id	text_1	text_2	text_1_name	text_2_name
0	news_test_0	According to him, this situation is caused by ...	Menurut Hilman, sepinya penumpang karena banya...	eng	ind
1	news_test_1	Amnesty says that to prop up their finances, l...	Amnesty mengatakan untuk meningkatkan anggaran...	eng	ind
2	news_test_2	There have been objections from oil and natura...	Perusahaan gas dan juga industri ikan mengajuk...	eng	ind
3	news_test_3	A researcher in Denmark has discovered a previ...	Seorang peneliti di Denmark menemukan dongeng ...	eng	ind
4	news_test_4	The BBC Washington correspondent says the Supr...	Wartawan BBC di Washington mengatakan MA tampa...	eng	ind
...	...	...	...	...	...
1949	news_test_1949	The latest global assessment of threatened pla...	Penelitian global terbaru tentang spesies tumb...	eng	ind
1950	news_test_1950	Prisoner have escaped from a jail\n	Tahanan lari dari penjara\n	eng	ind
1951	news_test_1951	Australia considers new 'slavery' law\n	Australia pertimbangan UU baru 'perbudakan'\n	eng	ind
1952	news_test_1952	Experts on international aid say financial sup...	Para ahli bantuan internasional mengatakan duk...	eng	ind
1953	news_test_1953	But its percentage is almost the same," he fin...	Tapi persentasenya hampir sama," tandasnya.\n	eng	ind
1954 rows × 5 columns
```
