### PR TITLE
Closes #91 | Add NusaX-MT

### DIFF
--- a/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
+++ b/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
@@ -107,7 +107,7 @@ class NusaXMT(datasets.GeneratorBasedBuilder):
         if self.config.schema == "source" or self.config.schema == "nusantara_t2t":
             features = schemas.text2text_features
         else:
-            raise ValueError(f"Invalid config: {self.config.name}")
+            raise ValueError(f"Invalid config schema: {self.config.schema}")
 
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
@@ -140,7 +140,7 @@ class NusaXMT(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
         if self.config.schema != "source" and self.config.schema != "nusantara_t2t":
-            raise ValueError(f"Invalid config: {self.config.name}")
+            raise ValueError(f"Invalid config schema: {self.config.schema}")
 
         df = pd.read_csv(filepath).reset_index()
         if self.config.name == "nusax_mt_source" or self.config.name == "nusax_mt_nusantara_t2t":

--- a/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
+++ b/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
@@ -1,180 +1,119 @@
-# coding=utf-8
-# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-"""
-This template serves as a starting point for contributing a dataset to the Nusantara Dataset repo.
-
-When modifying it for your dataset, look for TODO items that offer specific instructions.
-
-Full documentation on writing dataset loading scripts can be found here:
-https://huggingface.co/docs/datasets/add_dataset.html
-
-To create a dataset loading script you will create a class and implement 3 methods:
-  * `_info`: Establishes the schema for the dataset, and returns a datasets.DatasetInfo object.
-  * `_split_generators`: Downloads and extracts data for each split (e.g. train/val/test) or associate local data with each split.
-  * `_generate_examples`: Creates examples from data on disk that conform to each schema defined in `_info`.
-
-TODO: Before submitting your script, delete this doc string and replace it with a description of your dataset.
-
-[nusantara_schema_name] = (kb, pairs, qa, text, t2t, entailment)
-"""
-import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
 import datasets
+import pandas as pd
 
+from nusantara.utils import schemas
 from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import (DEFAULT_NUSANTARA_VIEW_NAME,
+                                       DEFAULT_SOURCE_VIEW_NAME, Tasks)
 
-# TODO: Add BibTeX citation
+_DATASETNAME = "nusax_mt"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
+
+_LANGUAGES = ["ind", "ace", "ban", "bjn", "bbc", "bug", "jav", "mad", "min", "nij", "sun", "eng"]  # We follow ISO639-3 language code (https://iso639-3.sil.org/code_tables/639/data)
+
 _CITATION = """\
-@article{,
-  author    = {},
-  title     = {},
-  journal   = {},
-  volume    = {},
-  year      = {},
-  url       = {},
-  doi       = {},
-  biburl    = {},
-  bibsource = {}
+@misc{winata2022nusax,
+      title={NusaX: Multilingual Parallel Sentiment Dataset for 10 Indonesian Local Languages},
+      author={Winata, Genta Indra and Aji, Alham Fikri and Cahyawijaya,
+      Samuel and Mahendra, Rahmad and Koto, Fajri and Romadhony,
+      Ade and Kurniawan, Kemal and Moeljadi, David and Prasojo,
+      Radityo Eko and Fung, Pascale and Baldwin, Timothy and Lau,
+      Jey Han and Sennrich, Rico and Ruder, Sebastian},
+      year={2022},
+      eprint={2205.15960},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
 }
 """
 
-# TODO: create a module level variable with your dataset name (should match script name)
-#  E.g. Hallmarks of Cancer: [dataset_name] --> hallmarks_of_cancer
-_DATASETNAME = "[dataset_name]"
-
-# TODO: Add description of the dataset here
-# You can copy an official description
 _DESCRIPTION = """\
-This dataset is designed for XXX NLP task.
+NusaX is a high-quality multilingual parallel corpus that covers 12 languages, Indonesian, English, and 10 Indonesian local languages, namely Acehnese, Balinese, Banjarese, Buginese, Madurese, Minangkabau, Javanese, Ngaju, Sundanese, and Toba Batak.
+
+NusaX-MT is a parallel corpus for training and benchmarking machine translation models across 10 Indonesian local languages + Indonesian and English. The data is presented in csv format with 12 columns, one column for each language.
 """
 
-# TODO: Add a link to an official homepage for the dataset here (if possible)
-_HOMEPAGE = ""
+_HOMEPAGE = "https://github.com/IndoNLP/nusax/tree/main/datasets/mt"
 
-# TODO: Add the licence for the dataset here (if possible)
-# Note that this doesn't have to be a common open source license.
-# Some datasets have custom licenses. In this case, simply put the full license terms
-# into `_LICENSE`
-_LICENSE = ""
+_LICENSE = "Creative Commons Attribution Share-Alike 4.0 International"
 
-# TODO: Add links to the urls needed to download your dataset files.
-#  For local datasets, this variable can be an empty dictionary.
+_SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS]
 
-# For publicly available datasets you will most likely end up passing these URLs to dl_manager in _split_generators.
-# In most cases the URLs will be the same for the source and nusantara config.
-# However, if you need to access different files for each config you can have multiple entries in this dict.
-# This can be an arbitrarily nested dict/list of URLs (see below in `_split_generators` method)
-_URLS = {
-    _DATASETNAME: "url or list of urls or ... ",
-}
-
-# TODO: add supported task by dataset. One dataset may support multiple tasks
-_SUPPORTED_TASKS = []  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
-
-# TODO: set this to a version that is associated with the dataset. if none exists use "1.0.0"
-#  This version doesn't have to be consistent with semantic versioning. Anything that is
-#  provided by the original dataset as a version goes.
-_SOURCE_VERSION = ""
+_SOURCE_VERSION = "1.0.0"
 
 _NUSANTARA_VERSION = "1.0.0"
 
+_URLS = {
+    "train": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/mt/{lang}/train.csv",
+    "validation": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/mt/{lang}/valid.csv",
+    "test": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/mt/{lang}/test.csv",
+}
 
-# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
-class NewDataset(datasets.GeneratorBasedBuilder):
-    """TODO: Short description of my dataset."""
 
-    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
-    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+def nusantara_config_constructor(lang_source, lang_target, schema, version):
+    """Construct NusantaraConfig with nusax_mt_{lang_source}_{lang_target}_{schema} as the name format"""
+    if schema != "source" and schema != "nusantara_text":
+        raise ValueError(f"Invalid schema: {schema}")
 
-    # You will be able to load the "source" or "nusantara" configurations with
-    # ds_source = datasets.load_dataset('my_dataset', name='source')
-    # ds_nusantara = datasets.load_dataset('my_dataset', name='nusantara')
+    if lang == "":
+        return NusantaraConfig(
+            name="nusax_mt_{schema}".format(schema=schema),
+            version=datasets.Version(version),
+            description="nusax_mt with {schema} schema for all 132 language pairs".format(schema=schema),
+            schema=schema,
+            subset_id="nusax_mt",
+        )
+    else:
+        return NusantaraConfig(
+            name="nusax_mt_{lang_source}_{lang_target}_{schema}".format(lang_source=lang_source, lang_target=lang_target, schema=schema),
+            version=datasets.Version(version),
+            description="nusax_mt with {schema} schema for {lang} language".format(lang=lang, schema=schema),
+            schema=schema,
+            subset_id="nusax_mt",
+        )
 
-    # For local datasets you can make use of the `data_dir` and `data_files` kwargs
-    # https://huggingface.co/docs/datasets/add_dataset.html#downloading-data-files-and-organizing-splits
-    # ds_source = datasets.load_dataset('my_dataset', name='source', data_dir="/path/to/data/files")
-    # ds_nusantara = datasets.load_dataset('my_dataset', name='nusantara', data_dir="/path/to/data/files")
 
-    # TODO: For each dataset, implement Config for Source and Nusantara;
-    #  If dataset contains more than one subset (see nusantara/nusa_datasets/smsa.py) implement for EACH of them.
-    #  Each of them should contain:
-    #   - name: should be unique for each dataset config eg. smsa_(source|nusantara)_[nusantara_schema_name]
-    #   - version: option = (SOURCE_VERSION|NUSANTARA_VERSION)
-    #   - description: one line description for the dataset
-    #   - schema: options = (source|nusantara_[nusantara_schema_name])
-    #   - subset_id: subset id is the canonical name for the dataset (eg. smsa)
-    #  where [nusantara_schema_name] = (kb, pairs, qa, text, t2t)
+LANGUAGES_MAP = {
+    "ace": "acehnese",
+    "ban": "balinese",
+    "bjn": "banjarese",
+    "bug": "buginese",
+    "eng": "english",
+    "ind": "indonesian",
+    "jav": "javanese",
+    "mad": "madurese",
+    "min": "minangkabau",
+    "nij": "ngaju",
+    "sun": "sundanese",
+    "bbc": "toba_batak",
+}
 
-    BUILDER_CONFIGS = [
-        NusantaraConfig(
-            name="[dataset_name]_source",
-            version=SOURCE_VERSION,
-            description="[dataset_name] source schema",
-            schema="source",
-            subset_id="[dataset_name]",
-        ),
-        NusantaraConfig(
-            name="[dataset_name]_nusantara_[nusantara_schema_name]",
-            version=NUSANTARA_VERSION,
-            description="[dataset_name] Nusantara schema",
-            schema="nusantara_[nusantara_schema_name]",
-            subset_id="[dataset_name]",
-        ),
-    ]
 
-    DEFAULT_CONFIG_NAME = "[dataset_name]_source"
+class NusaXMT(datasets.GeneratorBasedBuilder):
+    """NusaX-MT is a parallel corpus for training and benchmarking machine translation models across 10 Indonesian local languages + Indonesian and English. The data is presented in csv format with 12 columns, one column for each language."""
+
+    BUILDER_CONFIGS = (
+        [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP]
+        + [nusantara_config_constructor(lang, "nusantara_text", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
+        + [nusantara_config_constructor("", "source", _SOURCE_VERSION), nusantara_config_constructor("", "nusantara_text", _NUSANTARA_VERSION)]
+    )
+
+    DEFAULT_CONFIG_NAME = "nusax_senti_ind_source"
 
     def _info(self) -> datasets.DatasetInfo:
-
-        # Create the source schema; this schema will keep all keys/information/labels as close to the original dataset as possible.
-
-        # You can arbitrarily nest lists and dictionaries.
-        # For iterables, use lists over tuples or `datasets.Sequence`
-
         if self.config.schema == "source":
-            # TODO: Create your source schema here
-            raise NotImplementedError()
-
-            # EX: Arbitrary NER type dataset
-            # features = datasets.Features(
-            #    {
-            #        "doc_id": datasets.Value("string"),
-            #        "text": datasets.Value("string"),
-            #        "entities": [
-            #            {
-            #                "offsets": [datasets.Value("int64")],
-            #                "text": datasets.Value("string"),
-            #                "type": datasets.Value("string"),
-            #                "entity_id": datasets.Value("string"),
-            #            }
-            #        ],
-            #    }
-            # )
-
-        # Choose the appropriate nusantara schema for your task and copy it here. You can find information on the schemas in the CONTRIBUTING guide.
-
-        # In rare cases you may get a dataset that supports multiple tasks requiring multiple schemas. In that case you can define multiple nusantara configs with a nusantara_[nusantara_schema_name] format.
-
-        # For example nusantara_kb, nusantara_t2t
-        elif self.config.schema == "nusantara_[nusantara_schema_name]":
-            # e.g. features = schemas.kb_features
-            # TODO: Choose your nusantara schema here
-            raise NotImplementedError()
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "label": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "nusantara_text":
+            features = schemas.text_features(["negative", "neutral", "positive"])
 
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
@@ -186,84 +125,46 @@ class NewDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-        # TODO: This method is tasked with downloading/extracting the data and defining the splits depending on the configuration
-
-        # If you need to access the "source" or "nusantara" config choice, that will be in self.config.name
-
-        # LOCAL DATASETS: You do not need the dl_manager; you can ignore this argument. Make sure `gen_kwargs` in the return gets passed the right filepath
-
-        # PUBLIC DATASETS: Assign your data-dir based on the dl_manager.
-
-        # dl_manager is a datasets.download.DownloadManager that can be used to download and extract URLs; many examples use the download_and_extract method; see the DownloadManager docs here: https://huggingface.co/docs/datasets/package_reference/builder_classes.html#datasets.DownloadManager
-
-        # dl_manager can accept any type of nested list/dict and will give back the same structure with the url replaced with the path to local files.
-
-        # TODO: KEEP if your dataset is PUBLIC; remove if not
-        urls = _URLS[_DATASETNAME]
-        data_dir = dl_manager.download_and_extract(urls)
-
-        # TODO: KEEP if your dataset is LOCAL; remove if NOT
-        if self.config.data_dir is None:
-            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+        if self.config.name == "nusax_senti_source" or self.config.name == "nusax_senti_nusantara_text":
+            # Load all 12 languages
+            train_csv_path = dl_manager.download_and_extract([_URLS["train"].format(lang=LANGUAGES_MAP[lang]) for lang in LANGUAGES_MAP])
+            validation_csv_path = dl_manager.download_and_extract([_URLS["validation"].format(lang=LANGUAGES_MAP[lang]) for lang in LANGUAGES_MAP])
+            test_csv_path = dl_manager.download_and_extract([_URLS["test"].format(lang=LANGUAGES_MAP[lang]) for lang in LANGUAGES_MAP])
         else:
-            data_dir = self.config.data_dir
-
-        # Not all datasets have predefined canonical train/val/test splits.
-        # If your dataset has no predefined splits, use datasets.Split.TRAIN for all of the data.
+            lang = self.config.name[12:15]
+            train_csv_path = Path(dl_manager.download_and_extract(_URLS["train"].format(lang=LANGUAGES_MAP[lang])))
+            validation_csv_path = Path(dl_manager.download_and_extract(_URLS["validation"].format(lang=LANGUAGES_MAP[lang])))
+            test_csv_path = Path(dl_manager.download_and_extract(_URLS["test"].format(lang=LANGUAGES_MAP[lang])))
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                # Whatever you put in gen_kwargs will be passed to _generate_examples
-                gen_kwargs={
-                    "filepath": os.path.join(data_dir, "train.jsonl"),
-                    "split": "train",
-                },
-            ),
-            datasets.SplitGenerator(
-                name=datasets.Split.TEST,
-                gen_kwargs={
-                    "filepath": os.path.join(data_dir, "test.jsonl"),
-                    "split": "test",
-                },
+                gen_kwargs={"filepath": train_csv_path},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
-                gen_kwargs={
-                    "filepath": os.path.join(data_dir, "dev.jsonl"),
-                    "split": "dev",
-                },
+                gen_kwargs={"filepath": validation_csv_path},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": test_csv_path},
             ),
         ]
 
-    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        if self.config.schema != "source" and self.config.schema != "nusantara_text":
+            raise ValueError(f"Invalid config: {self.config.name}")
 
-    # TODO: change the args of this function to match the keys in `gen_kwargs`. You may add any necessary kwargs.
+        if self.config.name == "nusax_senti_source" or self.config.name == "nusax_senti_nusantara_text":
+            ldf = []
+            for fp in filepath:
+                ldf.append(pd.read_csv(fp))
+            df = pd.concat(ldf, axis=0, ignore_index=True).reset_index()
+            # Have to use index instead of id to avoid duplicated key
+            df = df.drop(columns=["id"]).rename(columns={"index": "id"})
+        else:
+            df = pd.read_csv(filepath).reset_index()
 
-    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
-        """Yields examples as (key, example) tuples."""
-        # TODO: This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
-
-        # The `key` is for legacy reasons (tfds) and is not important in itself, but must be unique for each example.
-
-        # NOTE: For local datasets you will have access to self.config.data_dir and self.config.data_files
-
-        if self.config.schema == "source":
-            # TODO: yield (key, example) tuples in the original dataset schema
-            for key, example in thing:
-                yield key, example
-
-        elif self.config.schema == "nusantara_[nusantara_schema_name]":
-            # TODO: yield (key, example) tuples in the nusantara schema
-            for key, example in thing:
-                yield key, example
-
-
-# This template is based on the following template from the datasets package:
-# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
-
-
-# This allows you to run your dataloader with `python [dataset_name].py` during development
-# TODO: Remove this before making your PR
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)
+        for row in df.itertuples():
+            ex = {"id": str(row.id), "text": row.text, "label": row.label}
+            yield row.id, ex

--- a/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
+++ b/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
@@ -1,0 +1,269 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This template serves as a starting point for contributing a dataset to the Nusantara Dataset repo.
+
+When modifying it for your dataset, look for TODO items that offer specific instructions.
+
+Full documentation on writing dataset loading scripts can be found here:
+https://huggingface.co/docs/datasets/add_dataset.html
+
+To create a dataset loading script you will create a class and implement 3 methods:
+  * `_info`: Establishes the schema for the dataset, and returns a datasets.DatasetInfo object.
+  * `_split_generators`: Downloads and extracts data for each split (e.g. train/val/test) or associate local data with each split.
+  * `_generate_examples`: Creates examples from data on disk that conform to each schema defined in `_info`.
+
+TODO: Before submitting your script, delete this doc string and replace it with a description of your dataset.
+
+[nusantara_schema_name] = (kb, pairs, qa, text, t2t, entailment)
+"""
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from nusantara.utils.configs import NusantaraConfig
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@article{,
+  author    = {},
+  title     = {},
+  journal   = {},
+  volume    = {},
+  year      = {},
+  url       = {},
+  doi       = {},
+  biburl    = {},
+  bibsource = {}
+}
+"""
+
+# TODO: create a module level variable with your dataset name (should match script name)
+#  E.g. Hallmarks of Cancer: [dataset_name] --> hallmarks_of_cancer
+_DATASETNAME = "[dataset_name]"
+
+# TODO: Add description of the dataset here
+# You can copy an official description
+_DESCRIPTION = """\
+This dataset is designed for XXX NLP task.
+"""
+
+# TODO: Add a link to an official homepage for the dataset here (if possible)
+_HOMEPAGE = ""
+
+# TODO: Add the licence for the dataset here (if possible)
+# Note that this doesn't have to be a common open source license.
+# Some datasets have custom licenses. In this case, simply put the full license terms
+# into `_LICENSE`
+_LICENSE = ""
+
+# TODO: Add links to the urls needed to download your dataset files.
+#  For local datasets, this variable can be an empty dictionary.
+
+# For publicly available datasets you will most likely end up passing these URLs to dl_manager in _split_generators.
+# In most cases the URLs will be the same for the source and nusantara config.
+# However, if you need to access different files for each config you can have multiple entries in this dict.
+# This can be an arbitrarily nested dict/list of URLs (see below in `_split_generators` method)
+_URLS = {
+    _DATASETNAME: "url or list of urls or ... ",
+}
+
+# TODO: add supported task by dataset. One dataset may support multiple tasks
+_SUPPORTED_TASKS = []  # example: [Tasks.TRANSLATION, Tasks.NAMED_ENTITY_RECOGNITION, Tasks.RELATION_EXTRACTION]
+
+# TODO: set this to a version that is associated with the dataset. if none exists use "1.0.0"
+#  This version doesn't have to be consistent with semantic versioning. Anything that is
+#  provided by the original dataset as a version goes.
+_SOURCE_VERSION = ""
+
+_NUSANTARA_VERSION = "1.0.0"
+
+
+# TODO: Name the dataset class to match the script name using CamelCase instead of snake_case
+class NewDataset(datasets.GeneratorBasedBuilder):
+    """TODO: Short description of my dataset."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+
+    # You will be able to load the "source" or "nusantara" configurations with
+    # ds_source = datasets.load_dataset('my_dataset', name='source')
+    # ds_nusantara = datasets.load_dataset('my_dataset', name='nusantara')
+
+    # For local datasets you can make use of the `data_dir` and `data_files` kwargs
+    # https://huggingface.co/docs/datasets/add_dataset.html#downloading-data-files-and-organizing-splits
+    # ds_source = datasets.load_dataset('my_dataset', name='source', data_dir="/path/to/data/files")
+    # ds_nusantara = datasets.load_dataset('my_dataset', name='nusantara', data_dir="/path/to/data/files")
+
+    # TODO: For each dataset, implement Config for Source and Nusantara;
+    #  If dataset contains more than one subset (see nusantara/nusa_datasets/smsa.py) implement for EACH of them.
+    #  Each of them should contain:
+    #   - name: should be unique for each dataset config eg. smsa_(source|nusantara)_[nusantara_schema_name]
+    #   - version: option = (SOURCE_VERSION|NUSANTARA_VERSION)
+    #   - description: one line description for the dataset
+    #   - schema: options = (source|nusantara_[nusantara_schema_name])
+    #   - subset_id: subset id is the canonical name for the dataset (eg. smsa)
+    #  where [nusantara_schema_name] = (kb, pairs, qa, text, t2t)
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="[dataset_name]_source",
+            version=SOURCE_VERSION,
+            description="[dataset_name] source schema",
+            schema="source",
+            subset_id="[dataset_name]",
+        ),
+        NusantaraConfig(
+            name="[dataset_name]_nusantara_[nusantara_schema_name]",
+            version=NUSANTARA_VERSION,
+            description="[dataset_name] Nusantara schema",
+            schema="nusantara_[nusantara_schema_name]",
+            subset_id="[dataset_name]",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "[dataset_name]_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        # Create the source schema; this schema will keep all keys/information/labels as close to the original dataset as possible.
+
+        # You can arbitrarily nest lists and dictionaries.
+        # For iterables, use lists over tuples or `datasets.Sequence`
+
+        if self.config.schema == "source":
+            # TODO: Create your source schema here
+            raise NotImplementedError()
+
+            # EX: Arbitrary NER type dataset
+            # features = datasets.Features(
+            #    {
+            #        "doc_id": datasets.Value("string"),
+            #        "text": datasets.Value("string"),
+            #        "entities": [
+            #            {
+            #                "offsets": [datasets.Value("int64")],
+            #                "text": datasets.Value("string"),
+            #                "type": datasets.Value("string"),
+            #                "entity_id": datasets.Value("string"),
+            #            }
+            #        ],
+            #    }
+            # )
+
+        # Choose the appropriate nusantara schema for your task and copy it here. You can find information on the schemas in the CONTRIBUTING guide.
+
+        # In rare cases you may get a dataset that supports multiple tasks requiring multiple schemas. In that case you can define multiple nusantara configs with a nusantara_[nusantara_schema_name] format.
+
+        # For example nusantara_kb, nusantara_t2t
+        elif self.config.schema == "nusantara_[nusantara_schema_name]":
+            # e.g. features = schemas.kb_features
+            # TODO: Choose your nusantara schema here
+            raise NotImplementedError()
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        # TODO: This method is tasked with downloading/extracting the data and defining the splits depending on the configuration
+
+        # If you need to access the "source" or "nusantara" config choice, that will be in self.config.name
+
+        # LOCAL DATASETS: You do not need the dl_manager; you can ignore this argument. Make sure `gen_kwargs` in the return gets passed the right filepath
+
+        # PUBLIC DATASETS: Assign your data-dir based on the dl_manager.
+
+        # dl_manager is a datasets.download.DownloadManager that can be used to download and extract URLs; many examples use the download_and_extract method; see the DownloadManager docs here: https://huggingface.co/docs/datasets/package_reference/builder_classes.html#datasets.DownloadManager
+
+        # dl_manager can accept any type of nested list/dict and will give back the same structure with the url replaced with the path to local files.
+
+        # TODO: KEEP if your dataset is PUBLIC; remove if not
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        # TODO: KEEP if your dataset is LOCAL; remove if NOT
+        if self.config.data_dir is None:
+            raise ValueError("This is a local dataset. Please pass the data_dir kwarg to load_dataset.")
+        else:
+            data_dir = self.config.data_dir
+
+        # Not all datasets have predefined canonical train/val/test splits.
+        # If your dataset has no predefined splits, use datasets.Split.TRAIN for all of the data.
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                # Whatever you put in gen_kwargs will be passed to _generate_examples
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "train.jsonl"),
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "test.jsonl"),
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "dev.jsonl"),
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+
+    # TODO: change the args of this function to match the keys in `gen_kwargs`. You may add any necessary kwargs.
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # TODO: This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+
+        # The `key` is for legacy reasons (tfds) and is not important in itself, but must be unique for each example.
+
+        # NOTE: For local datasets you will have access to self.config.data_dir and self.config.data_files
+
+        if self.config.schema == "source":
+            # TODO: yield (key, example) tuples in the original dataset schema
+            for key, example in thing:
+                yield key, example
+
+        elif self.config.schema == "nusantara_[nusantara_schema_name]":
+            # TODO: yield (key, example) tuples in the nusantara schema
+            for key, example in thing:
+                yield key, example
+
+
+# This template is based on the following template from the datasets package:
+# https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py
+
+
+# This allows you to run your dataloader with `python [dataset_name].py` during development
+# TODO: Remove this before making your PR
+if __name__ == "__main__":
+    datasets.load_dataset(__file__)

--- a/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
+++ b/nusantara/nusa_datasets/nusax_mt/nusax_mt.py
@@ -157,8 +157,8 @@ class NusaXMT(datasets.GeneratorBasedBuilder):
                             "id": str(id_count),
                             "text_1": row[LANGUAGES_MAP[lang_source]],
                             "text_2": row[LANGUAGES_MAP[lang_target]],
-                            "text_1_name": LANGUAGES_MAP[lang_source],
-                            "text_2_name": LANGUAGES_MAP[lang_target],
+                            "text_1_name": lang_source,
+                            "text_2_name": lang_target,
                         }
                         yield id_count, ex
 
@@ -172,7 +172,7 @@ class NusaXMT(datasets.GeneratorBasedBuilder):
                     "id": str(index),
                     "text_1": row[LANGUAGES_MAP[lang_source]],
                     "text_2": row[LANGUAGES_MAP[lang_target]],
-                    "text_1_name": LANGUAGES_MAP[lang_source],
-                    "text_2_name": LANGUAGES_MAP[lang_target],
+                    "text_1_name": lang_source,
+                    "text_2_name": lang_target,
                 }
                 yield str(index), ex


### PR DESCRIPTION
Hello Nusa-crowd team 👋 :D
This PR adds a dataloader for NusaX-MT and closes https://github.com/IndoNLP/nusa-crowd/issues/91.

On naming the config, I follow an approach similar to https://github.com/IndoNLP/nusa-crowd/pull/101 PR. To load 2 pairs of languages:
```
nusax_mt_{lang_1}_{lang_2}_{schema}
```

With two special cases, if the name is any of the following, then it'll load all 132 language pairs :
```
nusax_mt_source
nusax_mt_nusantara_t2t
```

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
