### PR TITLE
Adds the Wikiann NER corpus for 8 Indonesian languages

### DIFF
--- a/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
+++ b/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
@@ -12,7 +12,7 @@ _DATASETNAME = "wiki_ann"
 _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
 _UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
 
-_LANGUAGES = ["id", "en"]
+_LANGUAGES = ["ind", "eng"]
 _LOCAL = False
 _CITATION = """\
 @inproceedings{pan-etal-2017-cross,

--- a/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
+++ b/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
@@ -59,6 +59,10 @@ _CITATION = """\
 
 _DESCRIPTION = """\
 The wiki_ann dataset contains NER tags with labels from O (0), B-PER (1), I-PER (2), B-ORG (3), I-ORG (4), B-LOC (5), I-LOC (6). The Indonesian subset is used.
+WikiANN (sometimes called PAN-X) is a multilingual named entity recognition dataset consisting of Wikipedia articles
+ annotated with LOC (location), PER (person), and ORG (organisation)
+ tags in the IOB2 format. This version corresponds to the balanced train, dev, and test splits of
+  Rahimi et al. (2019), which supports 176 of the 282 languages from the original WikiANN corpus.
 """
 
 _HOMEPAGE = "https://github.com/afshinrahimi/mmner"

--- a/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
+++ b/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
@@ -1,0 +1,215 @@
+from pathlib import Path
+from typing import List
+
+import datasets
+
+from nusantara.utils import schemas
+from nusantara.utils.common_parser import load_conll_data
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import (DEFAULT_NUSANTARA_VIEW_NAME,
+                                       DEFAULT_SOURCE_VIEW_NAME, Tasks)
+
+_DATASETNAME = "wiki_ann"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
+
+_LANGUAGES = ["ind"]
+_LOCAL = False
+_CITATION = """\
+@inproceedings{pan-etal-2017-cross,
+    title = "Cross-lingual Name Tagging and Linking for 282 Languages",
+    author = "Pan, Xiaoman  and
+      Zhang, Boliang  and
+      May, Jonathan  and
+      Nothman, Joel  and
+      Knight, Kevin  and
+      Ji, Heng",
+    booktitle = "Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2017",
+    address = "Vancouver, Canada",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/P17-1178",
+    doi = "10.18653/v1/P17-1178",
+    pages = "1946--1958",
+    abstract = "The ambitious goal of this work is to develop a cross-lingual name tagging and linking framework for 282 languages that exist in Wikipedia. Given a document in any of these languages, our framework is able to identify name mentions, assign a coarse-grained or fine-grained type to each mention, and link it to an English Knowledge Base (KB) if it is linkable. We achieve this goal by performing a series of new KB mining methods: generating {``}silver-standard{''} annotations by transferring annotations from English to other languages through cross-lingual links and KB properties, refining annotations through self-training and topic selection, deriving language-specific morphology features from anchor links, and mining word translation pairs from cross-lingual links. Both name tagging and linking results for 282 languages are promising on Wikipedia data and on-Wikipedia data.",
+}
+@inproceedings{rahimi-etal-2019-massively,
+    title = "Massively Multilingual Transfer for {NER}",
+    author = "Rahimi, Afshin  and
+      Li, Yuan  and
+      Cohn, Trevor",
+    booktitle = "Proceedings of the 57th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/P19-1015",
+    pages = "151--164",
+}
+"""
+
+_DESCRIPTION = """\
+The wiki_ann dataset contains NER tags with labels from O (0), B-PER (1), I-PER (2), B-ORG (3), I-ORG (4), B-LOC (5), I-LOC (6). The Indonesian subset is used.
+"""
+
+_HOMEPAGE = "https://github.com/afshinrahimi/mmner"
+
+_LICENSE = "Apache-2.0 license"
+
+_URLs = {
+    "wiki_ann": "https://s3.amazonaws.com/datasets.huggingface.co/wikiann/1.1.0/panx_dataset.zip",
+}
+
+_SUPPORTED_TASKS = [Tasks.NAMED_ENTITY_RECOGNITION]
+
+_SOURCE_VERSION = "1.1.0"
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class WikiAnnDataset(datasets.GeneratorBasedBuilder):
+    """wiki_ann is an NER tagging dataset consisting of Wikipedia articles annotated with LOC, PER, and ORG tags"""
+
+    label_classes = ["B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "O"]
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="wiki_ann_source",
+            version=datasets.Version(_SOURCE_VERSION),
+            description="wiki_ann source schema",
+            schema="source",
+            subset_id="wiki_ann",
+        ),
+        NusantaraConfig(
+            name="wiki_ann_nusantara_seq_label",
+            version=datasets.Version(_NUSANTARA_VERSION),
+            description="wiki_ann Nusantara schema",
+            schema="nusantara_seq_label",
+            subset_id="wiki_ann",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "wiki_ann_source"
+
+    def _info(self):
+        if self.config.schema == "source":
+            features = datasets.Features({"index": datasets.Value("string"), "tokens": [datasets.Value("string")],
+                                          "ner_tag": [datasets.Value("string")]})
+        elif self.config.schema == "nusantara_seq_label":
+            features = schemas.seq_label_features(self.label_classes)
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        wikiann_dl_dir = Path(dl_manager.download_and_extract(_URLs["wiki_ann"])) / "id.tar.gz"
+        # paths = list(dl_manager.iter_archive(wikiann_dl_dir))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"split": "validtion", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"split": "test", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"split": "train", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
+            ),
+        ]
+
+    def _tags_to_spans(self, tags):
+        """Convert tags to spans. Based on https://github.com/huggingface/datasets/blob/main/datasets/wikiann/wikiann.py"""
+        spans = set()
+        span_start = 0
+        span_end = 0
+        active_conll_tag = None
+        for index, string_tag in enumerate(tags):
+            # Actual BIO tag.
+            bio_tag = string_tag[0]
+            assert bio_tag in ["B", "I", "O"], "Invalid Tag"
+            conll_tag = string_tag[2:]
+            if bio_tag == "O":
+                # The span has ended.
+                if active_conll_tag:
+                    spans.add((active_conll_tag, (span_start, span_end)))
+                active_conll_tag = None
+                # We don't care about tags we are
+                # told to ignore, so we do nothing.
+                continue
+            elif bio_tag == "B":
+                # We are entering a new span; reset indices and active tag to new span.
+                if active_conll_tag:
+                    spans.add((active_conll_tag, (span_start, span_end)))
+                active_conll_tag = conll_tag
+                span_start = index
+                span_end = index
+            elif bio_tag == "I" and conll_tag == active_conll_tag:
+                # We're inside a span.
+                span_end += 1
+            else:
+                # This is the case the bio label is an "I", but either:
+                # 1) the span hasn't started - i.e. an ill formed span.
+                # 2) We have IOB1 tagging scheme.
+                # We'll process the previous span if it exists, but also include this
+                # span. This is important, because otherwise, a model may get a perfect
+                # F1 score whilst still including false positive ill-formed spans.
+                if active_conll_tag:
+                    spans.add((active_conll_tag, (span_start, span_end)))
+                active_conll_tag = conll_tag
+                span_start = index
+                span_end = index
+        # Last token might have been a part of a valid span.
+        if active_conll_tag:
+            spans.add((active_conll_tag, (span_start, span_end)))
+        # Return sorted list of spans
+        return sorted(list(spans), key=lambda x: x[1][0])
+
+    def _get_spans(self, tokens, tags):
+        """Convert tags to textspans. Based on https://github.com/huggingface/datasets/blob/main/datasets/wikiann/wikiann.py"""
+        spans = self._tags_to_spans(tags)
+        text_spans = [x[0] + ": " + " ".join([tokens[i] for i in range(x[1][0], x[1][1] + 1)]) for x in spans]
+        if not text_spans:
+            text_spans = ["None"]
+        return text_spans
+
+    def _generate_examples(self, filepath: Path, split):
+        """Based on https://github.com/huggingface/datasets/blob/main/datasets/wikiann/wikiann.py"""
+        tokens = []
+        ner_tags = []
+        langs = []
+        guid_index = 1
+        for k, file in filepath:
+            if k == split:
+                for line in file:
+                    line = line.decode("utf-8")
+                    if line == "" or line == "\n":
+                        if tokens:
+                            spans = self._get_spans(tokens, ner_tags)
+                            if self.config.schema == "source":
+                                yield guid_index, {"index": str(guid_index), "tokens": tokens, "ner_tag": ner_tags}
+                            elif self.config.schema == "nusantara_seq_label":
+                                yield guid_index, {"id": str(guid_index), "tokens": tokens, "labels": ner_tags}
+                            else:
+                                raise ValueError(f"Invalid config: {self.config.name}")
+                            guid_index += 1
+                            tokens = []
+                            ner_tags = []
+                            langs = []
+                    else:
+                        # wikiann data is tab separated
+                        splits = line.split("\t")
+                        # strip out en: prefix
+                        langs.append(splits[0].split(":")[0])
+                        tokens.append(":".join(splits[0].split(":")[1:]))
+                        if len(splits) > 1:
+                            ner_tags.append(splits[-1].replace("\n", ""))
+                        else:
+                            # examples have no label in test set
+                            ner_tags.append("O")

--- a/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
+++ b/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
@@ -62,7 +62,7 @@ The wiki_ann dataset contains NER tags with labels from O (0), B-PER (1), I-PER 
 WikiANN (sometimes called PAN-X) is a multilingual named entity recognition dataset consisting of Wikipedia articles
  annotated with LOC (location), PER (person), and ORG (organisation)
  tags in the IOB2 format. This version corresponds to the balanced train, dev, and test splits of
-  Rahimi et al. (2019), which supports 176 of the 282 languages from the original WikiANN corpus.
+  Rahimi et al. (2019), and uses the Indonesian subset from the original WikiANN corpus.
 """
 
 _HOMEPAGE = "https://github.com/afshinrahimi/mmner"

--- a/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
+++ b/nusantara/nusa_datasets/wiki_ann/wiki_ann.py
@@ -102,9 +102,10 @@ def nusantara_config_constructor(lang, schema, version):
 
 
 LANGUAGES_MAP = {
-    "en": "english",
-    "id": "indonesian",
+    "eng": "english",
+    "ind": "indonesian",
 }
+LANG_CODES = {"eng": "en", "ind": "id"}
 
 
 class WikiAnnDataset(datasets.GeneratorBasedBuilder):
@@ -114,18 +115,16 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
     label_classes = ["B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "O"]
 
     BUILDER_CONFIGS = (
-            [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP]
-            + [nusantara_config_constructor(lang, "nusantara_seq_label", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
-            + [nusantara_config_constructor("", "source", _SOURCE_VERSION),
-               nusantara_config_constructor("", "nusantara_seq_label", _NUSANTARA_VERSION)]
+        [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP]
+        + [nusantara_config_constructor(lang, "nusantara_seq_label", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
+        + [nusantara_config_constructor("", "source", _SOURCE_VERSION), nusantara_config_constructor("", "nusantara_seq_label", _NUSANTARA_VERSION)]
     )
 
     DEFAULT_CONFIG_NAME = "wiki_ann_source"
 
     def _info(self):
         if self.config.schema == "source":
-            features = datasets.Features({"index": datasets.Value("string"), "tokens": [datasets.Value("string")],
-                                          "ner_tag": [datasets.Value("string")]})
+            features = datasets.Features({"index": datasets.Value("string"), "tokens": [datasets.Value("string")], "ner_tag": [datasets.Value("string")]})
         elif self.config.schema == "nusantara_seq_label":
             features = schemas.seq_label_features(self.label_classes)
 
@@ -139,11 +138,10 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         path = Path(dl_manager.download_and_extract(_URLs["wiki_ann"]))
-        print(self.config.name + "--->")
         if self.config.name == "wiki_ann_source" or self.config.name == "wiki_ann_nusantara_seq_label":
-            wikiann_dl_dir = path / f"id.tar.gz"
+            wikiann_dl_dir = path / "id.tar.gz"
         else:
-            lang = self.config.name[15:18]
+            lang = self.LANG_CODES[self.config.name[15:18]]
             wikiann_dl_dir = path / f"{lang}.tar.gz"
         return [
             datasets.SplitGenerator(
@@ -194,4 +192,3 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
                         else:
                             # examples have no label in test set
                             ner_tags.append("O")
-

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -72,11 +72,8 @@ Minangkabau	min	min
 Sundanese	su	sun
 Acehnese	ace	ace
 Malay	ms	mly
-Banyumasan	bms	map-bms
+Banyumasan	map-bms	map-bms
 
-The 3-letter code of Banyumasan has been kept changing from map-bms to bms.
-So, the configuration to access Banyumasan would be:
-"wikiann_bms_source"
 
 """
 
@@ -110,8 +107,8 @@ def nusantara_config_constructor(lang, schema, version):
     )
 
 
-LANGUAGES_MAP = {"eng": "english", "ind": "indonesian", "jav": "javanese", "min": "minangkabau", "sun": "sundanese", "ace": "acehnese", "mly": "malay", "bms": "banyumasan"}  # Actual code is map-bms
-LANG_CODES = {"eng": "en", "ind": "id", "jav": "jv", "min": "min", "sun": "su", "ace": "ace", "mly": "ms", "bms": "map-bms"}
+LANGUAGES_MAP = {"eng": "english", "ind": "indonesian", "jav": "javanese", "min": "minangkabau", "sun": "sundanese", "ace": "acehnese", "mly": "malay", "map_bms": "banyumasan"}  # Actual code is map-bms
+LANG_CODES = {"eng": "en", "ind": "id", "jav": "jv", "min": "min", "sun": "su", "ace": "ace", "mly": "ms", "map_bms": "map-bms"}
 
 
 class WikiAnnDataset(datasets.GeneratorBasedBuilder):
@@ -138,9 +135,12 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
             citation=_CITATION,
         )
 
+    def get_lang(self, name):
+        return name.removesuffix("_source").removesuffix("_nusantara_seq_label").removeprefix("wikiann_")
+
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
         path = Path(dl_manager.download_and_extract(_URLs["wikiann"]))
-        lang = LANG_CODES[self.config.name[8:11]]
+        lang = LANG_CODES[self.get_lang(self.config.name)]
         wikiann_dl_dir = path / f"{lang}.tar.gz"
         return [
             datasets.SplitGenerator(

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -133,7 +133,7 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
-                gen_kwargs={"split": "validation", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
+                gen_kwargs={"split": "dev", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
@@ -179,3 +179,7 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
                         else:
                             # examples have no label in test set
                             ner_tags.append("O")
+
+if __name__ == "__main__":
+    d = datasets.load_dataset(__file__)
+    print(d)

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -122,7 +122,7 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
 
     BUILDER_CONFIGS = [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP] + [nusantara_config_constructor(lang, "nusantara_seq_label", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
 
-    DEFAULT_CONFIG_NAME = "wikiann_bms_source"
+    DEFAULT_CONFIG_NAME = "wikiann_ind_source"
 
     def _info(self):
         if self.config.schema == "source":

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -80,16 +80,19 @@ _NUSANTARA_VERSION = "1.0.0"
 
 
 def nusantara_config_constructor(lang, schema, version):
-    if lang == "" or (schema != "source" and schema != "nusantara_seq_label"):
+    if lang == "":
+        raise ValueError(f"Invalid lang {lang}")
+
+    if schema != "source" and schema != "nusantara_seq_label":
         raise ValueError(f"Invalid schema: {schema}")
 
     return NusantaraConfig(
-            name="wikiann_{lang}_{schema}".format(lang=lang, schema=schema),
-            version=datasets.Version(version),
-            description="wikiann with {schema} schema for {lang} language".format(lang=lang, schema=schema),
-            schema=schema,
-            subset_id="wikiann",
-        )
+        name="wikiann_{lang}_{schema}".format(lang=lang, schema=schema),
+        version=datasets.Version(version),
+        description="wikiann with {schema} schema for {lang} language".format(lang=lang, schema=schema),
+        schema=schema,
+        subset_id="wikiann",
+    )
 
 
 LANGUAGES_MAP = {
@@ -105,10 +108,7 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
 
     label_classes = ["B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "O"]
 
-    BUILDER_CONFIGS = (
-        [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP]
-        + [nusantara_config_constructor(lang, "nusantara_seq_label", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
-    )
+    BUILDER_CONFIGS = [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP] + [nusantara_config_constructor(lang, "nusantara_seq_label", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
 
     DEFAULT_CONFIG_NAME = "wikiann_ind_source"
 
@@ -179,5 +179,3 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
                         else:
                             # examples have no label in test set
                             ner_tags.append("O")
-if __name__ == "__main__":
-    datasets.load_dataset(__file__)

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -63,7 +63,17 @@ The wikiann dataset contains NER tags with labels from O (0), B-PER (1), I-PER (
 WikiANN (sometimes called PAN-X) is a multilingual named entity recognition dataset consisting of Wikipedia articles
  annotated with LOC (location), PER (person), and ORG (organisation)
  tags in the IOB2 format. This version corresponds to the balanced train, dev, and test splits of
-  Rahimi et al. (2019), and uses the Indonesian subset from the original WikiANN corpus.
+  Rahimi et al. (2019), and uses the following subsets from the original WikiANN corpus
+
+Language	WikiAnn	ISO 639-3
+Indonesian	id	ind
+Javanese	jv	jav
+Minangkabau	min	min
+Sundanese	su	sun
+Acehnese	ace	ace
+Malay	ms	mly
+Banyumasan	bms	map-bms
+
 """
 
 _HOMEPAGE = "https://github.com/afshinrahimi/mmner"
@@ -99,8 +109,21 @@ def nusantara_config_constructor(lang, schema, version):
 LANGUAGES_MAP = {
     "eng": "english",
     "ind": "indonesian",
+    "jav": "javanese",
+    "min": "minangkabau",
+    "sun": "sundanese",
+    "ace": "acehnese",
+    "mly": "malay",
+    "bms": "banyumasan" # Actual code is map-bms
 }
-LANG_CODES = {"eng": "en", "ind": "id"}
+LANG_CODES = {"eng": "en",
+              "ind": "id",
+              "jav": "jv",
+              "min": "min",
+              "sun": "su",
+              "ace": "ace",
+              "mly": "ms",
+              "bms": "map-bms"}
 
 
 class WikiAnnDataset(datasets.GeneratorBasedBuilder):
@@ -111,7 +134,7 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
 
     BUILDER_CONFIGS = [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP] + [nusantara_config_constructor(lang, "nusantara_seq_label", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
 
-    DEFAULT_CONFIG_NAME = "wikiann_ind_source"
+    DEFAULT_CONFIG_NAME = "wikiann_bms_source"
 
     def _info(self):
         if self.config.schema == "source":

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -74,6 +74,10 @@ Acehnese	ace	ace
 Malay	ms	mly
 Banyumasan	bms	map-bms
 
+The 3-letter code of Banyumasan has been kept changing from map-bms to bms.
+So, the configuration to access Banyumasan would be:
+"wikiann_bms_source"
+
 """
 
 _HOMEPAGE = "https://github.com/afshinrahimi/mmner"
@@ -106,24 +110,8 @@ def nusantara_config_constructor(lang, schema, version):
     )
 
 
-LANGUAGES_MAP = {
-    "eng": "english",
-    "ind": "indonesian",
-    "jav": "javanese",
-    "min": "minangkabau",
-    "sun": "sundanese",
-    "ace": "acehnese",
-    "mly": "malay",
-    "bms": "banyumasan" # Actual code is map-bms
-}
-LANG_CODES = {"eng": "en",
-              "ind": "id",
-              "jav": "jv",
-              "min": "min",
-              "sun": "su",
-              "ace": "ace",
-              "mly": "ms",
-              "bms": "map-bms"}
+LANGUAGES_MAP = {"eng": "english", "ind": "indonesian", "jav": "javanese", "min": "minangkabau", "sun": "sundanese", "ace": "acehnese", "mly": "malay", "bms": "banyumasan"}  # Actual code is map-bms
+LANG_CODES = {"eng": "en", "ind": "id", "jav": "jv", "min": "min", "sun": "su", "ace": "ace", "mly": "ms", "bms": "map-bms"}
 
 
 class WikiAnnDataset(datasets.GeneratorBasedBuilder):
@@ -207,7 +195,3 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
                         else:
                             # examples have no label in test set
                             ner_tags.append("O")
-
-if __name__ == "__main__":
-    d = datasets.load_dataset(__file__)
-    print(d)

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List
 
 import datasets
+from datasets import NamedSplit
 
 from nusantara.utils import schemas
 from nusantara.utils.configs import NusantaraConfig
@@ -142,6 +143,10 @@ class WikiAnnDataset(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={"split": "train", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
+            ),
+            datasets.SplitGenerator(
+                name=NamedSplit("extra"),
+                gen_kwargs={"split": "extra", "filepath": dl_manager.iter_archive(wikiann_dl_dir)},
             ),
         ]
 

--- a/nusantara/nusa_datasets/wikiann/wikiann.py
+++ b/nusantara/nusa_datasets/wikiann/wikiann.py
@@ -13,7 +13,7 @@ _DATASETNAME = "wikiann"
 _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
 _UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
 
-_LANGUAGES = ["ind", "eng"]
+_LANGUAGES = ["ind", "eng", "jav", "min", "sun", "ace", "mly", "map-bms"]
 _LOCAL = False
 _CITATION = """\
 @inproceedings{pan-etal-2017-cross,


### PR DESCRIPTION
Closes #138 "

The code has been enabled for selecting any language. The languages map LANGUAGES_MAP & LANG_CODES needs to be filled with other languages which are Indonesian.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [ ] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
