### PR TITLE
Closes #109 | Implement Dataset loader for Netifier

### DIFF
--- a/nusantara/nusa_datasets/netifier/netifier.py
+++ b/nusantara/nusa_datasets/netifier/netifier.py
@@ -109,7 +109,7 @@ class IdAbusive(datasets.GeneratorBasedBuilder):
         if self.config.schema == "source":
             for row in df.itertuples():
                 ex = {
-                    "text": row.original_text,
+                    "text": row.text,
                 }
                 for label in label_cols:
                     ex[label] = getattr(row, label)
@@ -119,7 +119,7 @@ class IdAbusive(datasets.GeneratorBasedBuilder):
             for row in df.itertuples():
                 ex = {
                     "id": str(row.id),
-                    "text": row.original_text,
+                    "text": row.text,
                     "labels": [label for label in row[4:]],
                 }
                 yield row.id, ex

--- a/nusantara/nusa_datasets/netifier/netifier.py
+++ b/nusantara/nusa_datasets/netifier/netifier.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks
+
+_CITATION = """\
+"""
+
+_DATASETNAME = "id_multilabel_hs"
+
+_DESCRIPTION = """\
+Netifier dataset is a collection of scraped posts on famous social media sites in Indonesia,
+such as Instagram, Twitter, and Kaskus aimed to do multi-label toxicity classification.
+The dataset consists of 7,773 texts. The author manually labelled ~7k samples into 4 categories:
+pornography, hate speech, racism, and radicalism.
+"""
+
+_HOMEPAGE = "https://github.com/ahmadizzan/netifier"
+_LICENSE = "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+_URLS = {_DATASETNAME: {"train": "https://raw.githubusercontent.com/ahmadizzan/netifier/master/data/processed/train.csv", "test": "https://raw.githubusercontent.com/ahmadizzan/netifier/master/data/processed/test.csv"}}
+_SUPPORTED_TASKS = [Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS]
+_SOURCE_VERSION = "1.0.0"
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class IdAbusive(datasets.GeneratorBasedBuilder):
+    """Netifier dataset is a collection of scraped posts on famous social media sites in Indonesia,
+    such as Instagram, Twitter, and Kaskus aimed to do multi-label toxicity classification."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="netifier_source",
+            version=SOURCE_VERSION,
+            description="Netifier source schema",
+            schema="source",
+            subset_id="netifier",
+        ),
+        NusantaraConfig(
+            name="netifier_nusantara_text_multi",
+            version=NUSANTARA_VERSION,
+            description="Netifier Nusantara schema",
+            schema="nusantara_text_multi",
+            subset_id="netifier",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "netifier_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                    "pornography": datasets.Value("bool"),
+                    "blasphemy/racism": datasets.Value("bool"),
+                    "radicalism": datasets.Value("bool"),
+                    "defamation": datasets.Value("bool"),
+                }
+            )
+        elif self.config.schema == "nusantara_text_multi":
+            features = schemas.text_multi_features([0, 1])
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+        train_data = Path(dl_manager.download(urls["train"]))
+        test_data = Path(dl_manager.download(urls["test"]))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": train_data,
+                    "split": "train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "filepath": test_data,
+                    "split": "test",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # Dataset does not have id, using row index as id
+        label_cols = ["pornography", "blasphemy/racism", "radicalism", "defamation"]
+        df = pd.read_csv(filepath, encoding="ISO-8859-1").reset_index()
+        df.columns = ["id", "original_text", "text"] + label_cols
+
+        if self.config.schema == "source":
+            for row in df.itertuples():
+                ex = {
+                    "text": row.original_text,
+                }
+                for label in label_cols:
+                    ex[label] = getattr(row, label)
+                yield row.id, ex
+
+        elif self.config.schema == "nusantara_text_multi":
+            for row in df.itertuples():
+                ex = {
+                    "id": str(row.id),
+                    "text": row.original_text,
+                    "labels": [label for label in row[3:]],
+                }
+                yield row.id, ex
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/nusantara/nusa_datasets/netifier/netifier.py
+++ b/nusantara/nusa_datasets/netifier/netifier.py
@@ -28,7 +28,7 @@ _SOURCE_VERSION = "1.0.0"
 _NUSANTARA_VERSION = "1.0.0"
 
 
-class IdAbusive(datasets.GeneratorBasedBuilder):
+class Netifier(datasets.GeneratorBasedBuilder):
     """Netifier dataset is a collection of scraped posts on famous social media sites in Indonesia,
     such as Instagram, Twitter, and Kaskus aimed to do multi-label toxicity classification."""
 

--- a/nusantara/nusa_datasets/netifier/netifier.py
+++ b/nusantara/nusa_datasets/netifier/netifier.py
@@ -60,7 +60,7 @@ class IdAbusive(datasets.GeneratorBasedBuilder):
                 {
                     "text": datasets.Value("string"),
                     "pornography": datasets.Value("bool"),
-                    "blasphemy/racism": datasets.Value("bool"),
+                    "blasphemy_racism_discrimination": datasets.Value("bool"),
                     "radicalism": datasets.Value("bool"),
                     "defamation": datasets.Value("bool"),
                 }
@@ -102,7 +102,7 @@ class IdAbusive(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
         """Yields examples as (key, example) tuples."""
         # Dataset does not have id, using row index as id
-        label_cols = ["pornography", "blasphemy/racism", "radicalism", "defamation"]
+        label_cols = ["pornography", "blasphemy_racism_discrimination", "radicalism", "defamation"]
         df = pd.read_csv(filepath, encoding="ISO-8859-1").reset_index()
         df.columns = ["id", "original_text", "text"] + label_cols
 
@@ -120,7 +120,7 @@ class IdAbusive(datasets.GeneratorBasedBuilder):
                 ex = {
                     "id": str(row.id),
                     "text": row.original_text,
-                    "labels": [label for label in row[3:]],
+                    "labels": [label for label in row[4:]],
                 }
                 yield row.id, ex
         else:

--- a/nusantara/nusa_datasets/netifier/netifier.py
+++ b/nusantara/nusa_datasets/netifier/netifier.py
@@ -11,7 +11,7 @@ from nusantara.utils.constants import Tasks
 _CITATION = """\
 """
 
-_DATASETNAME = "id_multilabel_hs"
+_DATASETNAME = "netifier"
 
 _DESCRIPTION = """\
 Netifier dataset is a collection of scraped posts on famous social media sites in Indonesia,


### PR DESCRIPTION
### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [X] Confirm dataloader script works with `datasets.load_dataset` function.
- [X] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [X] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.


```
INFO:__main__:args: Namespace(path='nusantara/nusa_datasets/netifier/netifier.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: nusantara/nusa_datasets/netifier/netifier.py
INFO:__main__:self.SUBSET_ID: netifier
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module nusantara.nusa_datasets.netifier.netifier
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.ASPECT_BASED_SENTIMENT_ANALYSIS: 'ABSA'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'TEXT_MULTI'}
INFO:__main__:schemas_to_check: {'TEXT_MULTI'}
INFO:__main__:Checking load_dataset with config name netifier_source
Downloading and preparing dataset netifier/netifier_source to /Users/christianwbsn/.cache/huggingface/datasets/netifier/netifier_source/1.0.0/b438cb097d9591d3b7e4eb8388e92672c0db911643eacdbbe98ea4c131c3abab...
Dataset netifier downloaded and prepared to /Users/christianwbsn/.cache/huggingface/datasets/netifier/netifier_source/1.0.0/b438cb097d9591d3b7e4eb8388e92672c0db911643eacdbbe98ea4c131c3abab. Subsequent calls will reuse this data.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 527.98it/s]
INFO:__main__:Checking load_dataset with config name netifier_nusantara_text_multi
Downloading and preparing dataset netifier/netifier_nusantara_text_multi to /Users/christianwbsn/.cache/huggingface/datasets/netifier/netifier_nusantara_text_multi/1.0.0/b438cb097d9591d3b7e4eb8388e92672c0db911643eacdbbe98ea4c131c3abab...
Dataset netifier downloaded and prepared to /Users/christianwbsn/.cache/huggingface/datasets/netifier/netifier_nusantara_text_multi/1.0.0/b438cb097d9591d3b7e4eb8388e92672c0db911643eacdbbe98ea4c131c3abab. Subsequent calls will reuse this data.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 756.41it/s]
WARNING:datasets.builder:Reusing dataset netifier (/Users/christianwbsn/.cache/huggingface/datasets/netifier/netifier_source/1.0.0/b438cb097d9591d3b7e4eb8388e92672c0db911643eacdbbe98ea4c131c3abab)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 633.53it/s]
INFO:__main__:Dataset sample [source]
{'text': 'jabar memang provinsi barokah boleh juga woi anjing goblok propinsi yang paling banyak ngerusak dan ngebakar gereja itu jatim gak lu sebut propinsi lumbung nasbung tuh jatim propinsi penghasil gembong teroris terbanyak itu jateng gak lu sebut lumbung nasbung tuh jateng ngarang stereotip kok piliah pilih bangsat lu pecun', 'pornography': False, 'blasphemy_racism_discrimination': False, 'radicalism': False, 'defamation': True}
WARNING:datasets.builder:Reusing dataset netifier (/Users/christianwbsn/.cache/huggingface/datasets/netifier/netifier_nusantara_text_multi/1.0.0/b438cb097d9591d3b7e4eb8388e92672c0db911643eacdbbe98ea4c131c3abab)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 866.05it/s]
INFO:__main__:Dataset sample [nusantara_text_multi]
{'id': '0', 'text': 'jabar memang provinsi barokah boleh juga woi anjing goblok propinsi yang paling banyak ngerusak dan ngebakar gereja itu jatim gak lu sebut propinsi lumbung nasbung tuh jatim propinsi penghasil gembong teroris terbanyak itu jateng gak lu sebut lumbung nasbung tuh jateng ngarang stereotip kok piliah pilih bangsat lu pecun', 'labels': [0, 0, 0, 1]}
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 778 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 6995
text: 6995
labels: 27980

test
==========
id: 778
text: 778
labels: 3112

.
----------------------------------------------------------------------
Ran 1 test in 3.111s

OK
```
