### PR TITLE
Closes #129 | Implement dataset loader for SemEval STS Indo

### DIFF
--- a/nusantara/nusa_datasets/id_sts/id_sts.py
+++ b/nusantara/nusa_datasets/id_sts/id_sts.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks
+
+_CITATION = """
+"""
+
+_DATASETNAME = "id_sts"
+
+_DESCRIPTION = """\
+SemEval is a series of international natural language processing (NLP) research workshops whose mission is
+to advance the current state of the art in semantic analysis and to help create high-quality annotated datasets in a
+range of increasingly challenging problems in natural language semantics. This is a translated version of SemEval Dataset
+from 2012-2016 for Semantic Textual Similarity Task to Indonesian language.
+"""
+
+_HOMEPAGE = "https://github.com/ahmadizzan/sts-ind"
+
+_LICENSE = "Unknown"
+
+_URLS = {
+    _DATASETNAME: {
+        "train": "https://raw.githubusercontent.com/ahmadizzan/sts-indo/master/data/final-data/train.tsv",
+        "test": "https://raw.githubusercontent.com/ahmadizzan/sts-indo/master/data/final-data/test.tsv",
+    }
+}
+
+_SUPPORTED_TASKS = [Tasks.SEMANTIC_SIMILARITY]
+
+_SOURCE_VERSION = "1.0.0"
+
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class IdSts(datasets.GeneratorBasedBuilder):
+    """id_sts, translated version of SemEval Dataset
+    from 2012-2016 for Semantic Textual Similarity Task to Indonesian language"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="id_sts_source",
+            version=SOURCE_VERSION,
+            description="ID_STS source schema",
+            schema="source",
+            subset_id="id_sts",
+        ),
+        NusantaraConfig(
+            name="id_sts_nusantara_pairs",
+            version=NUSANTARA_VERSION,
+            description="ID_STS Nusantara schema",
+            schema="nusantara_pairs",
+            subset_id="id_sts",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "id_sts_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "text_1": datasets.Value("string"),
+                    "text_2": datasets.Value("string"),
+                    "score": datasets.Value("float32"),
+                }
+            )
+        elif self.config.schema == "nusantara_pairs":
+            features = schemas.pairs_features()
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        train_data_path = Path(dl_manager.download(urls["train"]))
+        test_data_path = Path(dl_manager.download(urls["test"]))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": train_data_path},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": test_data_path},
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # Dataset does not have id, using row index as id
+        df = pd.read_csv(filepath, delimiter="\t").reset_index()
+        df.columns = ["id", "score", "original_text_1", "original_text_2", "text_1", "text_2"]
+
+        if self.config.schema == "source":
+            for row in df.itertuples():
+                ex = {"text_1": row.text_1, "text_2": row.text_2, "score": row.score}
+                yield row.id, ex
+
+        elif self.config.schema == "nusantara_text_multi":
+            for row in df.itertuples():
+                ex = {"id": str(row.id), "text_1": row.text_1, "text_2": row.text_2, "score": row.score}
+                yield row.id, ex
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/nusantara/nusa_datasets/id_sts/id_sts.py
+++ b/nusantara/nusa_datasets/id_sts/id_sts.py
@@ -20,7 +20,7 @@ range of increasingly challenging problems in natural language semantics. This i
 from 2012-2016 for Semantic Textual Similarity Task to Indonesian language.
 """
 
-_HOMEPAGE = "https://github.com/ahmadizzan/sts-ind"
+_HOMEPAGE = "https://github.com/ahmadizzan/sts-indo"
 
 _LICENSE = "Unknown"
 

--- a/nusantara/utils/schemas/__init__.py
+++ b/nusantara/utils/schemas/__init__.py
@@ -1,5 +1,6 @@
 from .kb import features as kb_features
 from .pairs import features as pairs_features
+from .pairs import features_with_continuous_label as pairs_features_score
 from .qa import features as qa_features
 from .text import features as text_features
 from .text_multilabel import features as text_multi_features
@@ -8,4 +9,4 @@ from .seq_label import features as seq_label_features
 from .self_supervised_pretraining import features as ssp_features
 from .speech_recognition import features as asr_features
 
-__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "seq_label_features", "ssp_features", "asr_features"]
+__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "pairs_features_score", "seq_label_features", "ssp_features", "asr_features"]

--- a/nusantara/utils/schemas/pairs.py
+++ b/nusantara/utils/schemas/pairs.py
@@ -3,12 +3,24 @@ Text Pairs Schema
 """
 import datasets
 
-def features(label_names = ["Yes", "No"]):
+
+def features(label_names=["Yes", "No"]):
     return datasets.Features(
         {
             "id": datasets.Value("string"),
             "text_1": datasets.Value("string"),
             "text_2": datasets.Value("string"),
             "label": datasets.ClassLabel(names=label_names),
+        }
+    )
+
+
+def features_with_continuous_label():
+    return datasets.Features(
+        {
+            "id": datasets.Value("string"),
+            "text_1": datasets.Value("string"),
+            "text_2": datasets.Value("string"),
+            "label": datasets.Value("float64"),
         }
     )

--- a/tests/test_nusantara.py
+++ b/tests/test_nusantara.py
@@ -12,7 +12,7 @@ from typing import Iterable, Iterator, List, Optional, Union, Dict
 import datasets
 from datasets import DatasetDict, Features
 from nusantara.utils.constants import Tasks
-from nusantara.utils.schemas import kb_features, pairs_features, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features, asr_features
+from nusantara.utils.schemas import kb_features, pairs_features, pairs_features_score, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features, asr_features
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -33,7 +33,7 @@ _TASK_TO_SCHEMA = {
     Tasks.SENTENCE_ORDERING: "SEQ_LABEL",
     Tasks.QUESTION_ANSWERING: "QA",
     Tasks.TEXTUAL_ENTAILMENT: "PAIRS",
-    Tasks.SEMANTIC_SIMILARITY: "PAIRS",
+    Tasks.SEMANTIC_SIMILARITY: "PAIRS_SCORE",
     Tasks.NEXT_SENTENCE_PREDICTION: "PAIRS",
     Tasks.PARAPHRASING: "T2T",
     Tasks.MACHINE_TRANSLATION: "T2T",
@@ -55,6 +55,7 @@ _SCHEMA_TO_FEATURES = {
     "TEXT": text_features(),
     "TEXT_MULTI": text_multi_features(),
     "PAIRS": pairs_features(),
+    "PAIRS_SCORE": pairs_features_score(),
     "SEQ_LABEL": seq_label_features(),
     "SSP": ssp_features,
     "ASR": asr_features,
@@ -198,7 +199,7 @@ class TestDataLoader(unittest.TestCase):
             )
 
         # check dataset samples
-        for schema in ['source'] + [f"nusantara_{s.lower()}" for s in self.schemas_to_check]:
+        for schema in ["source"] + [f"nusantara_{s.lower()}" for s in self.schemas_to_check]:
             dataset = datasets.load_dataset(
                 self.PATH,
                 name=f"{self.SUBSET_ID}_{schema}",
@@ -206,7 +207,6 @@ class TestDataLoader(unittest.TestCase):
                 use_auth_token=self.USE_AUTH_TOKEN,
             )
             logger.info(f"Dataset sample [{schema}]\n{dataset[list(dataset.keys())[0]][0]}")
-
 
     def get_feature_statistics(self, features: Features, schema: str) -> Dict:
         """


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [X] Confirm dataloader script works with `datasets.load_dataset` function.
- [X] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [X] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

```
INFO:__main__:args: Namespace(path='nusantara/nusa_datasets/id_sts/id_sts.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: nusantara/nusa_datasets/id_sts/id_sts.py
INFO:__main__:self.SUBSET_ID: id_sts
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module nusantara.nusa_datasets.id_sts.id_sts
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.SEMANTIC_SIMILARITY: 'STS'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'PAIRS_SCORE'}
INFO:__main__:schemas_to_check: {'PAIRS_SCORE'}
INFO:__main__:Checking load_dataset with config name id_sts_source
WARNING:datasets.builder:Reusing dataset id_sts (/Users/christianwbsn/.cache/huggingface/datasets/id_sts/id_sts_source/1.0.0/d2691a87e223effeea0e8a2d5f40f1d319efbab09a0e78828ece2214b6c0725f)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 405.01it/s]
INFO:__main__:Checking load_dataset with config name id_sts_nusantara_pairs_score
WARNING:datasets.builder:Reusing dataset id_sts (/Users/christianwbsn/.cache/huggingface/datasets/id_sts/id_sts_nusantara_pairs_score/1.0.0/d2691a87e223effeea0e8a2d5f40f1d319efbab09a0e78828ece2214b6c0725f)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 710.78it/s]
WARNING:datasets.builder:Reusing dataset id_sts (/Users/christianwbsn/.cache/huggingface/datasets/id_sts/id_sts_source/1.0.0/d2691a87e223effeea0e8a2d5f40f1d319efbab09a0e78828ece2214b6c0725f)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 969.89it/s]
INFO:__main__:Dataset sample [source]
{'text_1': 'Sebuah sepeda motor diparkir di dekat dinding yang ditutupi dengan pemandangan grafiti pemandangan kota.', 'text_2': 'Sebuah sepeda motor diparkir oleh mural sebuah kota di malam hari.', 'label': 3.4}
WARNING:datasets.builder:Reusing dataset id_sts (/Users/christianwbsn/.cache/huggingface/datasets/id_sts/id_sts_nusantara_pairs_score/1.0.0/d2691a87e223effeea0e8a2d5f40f1d319efbab09a0e78828ece2214b6c0725f)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 153.06it/s]
INFO:__main__:Dataset sample [nusantara_pairs_score]
{'id': '0', 'text_1': 'Sebuah sepeda motor diparkir di dekat dinding yang ditutupi dengan pemandangan grafiti pemandangan kota.', 'text_2': 'Sebuah sepeda motor diparkir oleh mural sebuah kota di malam hari.', 'label': 3.4}
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 2580 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 10321
text_1: 10321
text_2: 10321
label: 10321

test
==========
id: 2580
text_1: 2580
text_2: 2580
label: 2580

.
----------------------------------------------------------------------
Ran 1 test in 2.282s

OK
```
