### PR TITLE
Closes #125 | Add Indo Puisi Dataloader

### DIFF
--- a/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
+++ b/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import (DEFAULT_NUSANTARA_VIEW_NAME,
+                                       DEFAULT_SOURCE_VIEW_NAME, Tasks)
+
+_DATASETNAME = "indo_puisi"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
+
+_CITATION = """
+"""
+
+_DESCRIPTION = """\
+"""
+
+_HOMEPAGE = "https://github.com/ilhamfp/puisi-pantun-generator"
+
+_LICENSE = "Creative Commons Attribution Share-Alike 4.0 International"
+
+_SUPPORTED_TASKS = [Tasks.SSP]
+
+_SOURCE_VERSION = "1.0.0"
+
+_NUSANTARA_VERSION = "1.0.0"
+
+_URLS = {
+    "train": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/sentiment/{lang}/train.csv",
+    "validation": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/sentiment/{lang}/valid.csv",
+    "test": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/sentiment/{lang}/test.csv",
+}
+
+
+def nusantara_config_constructor(lang, schema, version):
+    """Construct NusantaraConfig with nusax_senti_{lang}_{schema} as the name format"""
+    if schema != "source" and schema != "nusantara_text":
+        raise ValueError(f"Invalid schema: {schema}")
+
+    if lang == "":
+        return NusantaraConfig(
+            name="nusax_senti_{schema}".format(schema=schema),
+            version=datasets.Version(version),
+            description="nusax_senti with {schema} schema for all 12 languages".format(schema=schema),
+            schema=schema,
+            subset_id="nusax_senti",
+        )
+    else:
+        return NusantaraConfig(
+            name="nusax_senti_{lang}_{schema}".format(lang=lang, schema=schema),
+            version=datasets.Version(version),
+            description="nusax_senti with {schema} schema for {lang} language".format(lang=lang, schema=schema),
+            schema=schema,
+            subset_id="nusax_senti",
+        )
+
+
+LANGUAGES_MAP = {
+    "ace": "acehnese",
+    "ban": "balinese",
+    "bjn": "banjarese",
+    "bug": "buginese",
+    "eng": "english",
+    "ind": "indonesian",
+    "jav": "javanese",
+    "mad": "madurese",
+    "min": "minangkabau",
+    "nij": "ngaju",
+    "sun": "sundanese",
+    "bbc": "toba_batak",
+}
+
+
+class NusaXSenti(datasets.GeneratorBasedBuilder):
+    """NusaX-Senti is a 3-labels (positive, neutral, negative) sentiment analysis dataset for 10 Indonesian local languages + Indonesian and English."""
+
+    BUILDER_CONFIGS = (
+        [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP]
+        + [nusantara_config_constructor(lang, "nusantara_text", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
+        + [nusantara_config_constructor("", "source", _SOURCE_VERSION), nusantara_config_constructor("", "nusantara_text", _NUSANTARA_VERSION)]
+    )
+
+    DEFAULT_CONFIG_NAME = "nusax_senti_ind_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features(
+                {
+                    "id": datasets.Value("string"),
+                    "text": datasets.Value("string"),
+                    "label": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "nusantara_text":
+            features = schemas.text_features(["negative", "neutral", "positive"])
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        if self.config.name == "nusax_senti_source" or self.config.name == "nusax_senti_nusantara_text":
+            # Load all 12 languages
+            train_csv_path = dl_manager.download_and_extract([_URLS["train"].format(lang=LANGUAGES_MAP[lang]) for lang in LANGUAGES_MAP])
+            validation_csv_path = dl_manager.download_and_extract([_URLS["validation"].format(lang=LANGUAGES_MAP[lang]) for lang in LANGUAGES_MAP])
+            test_csv_path = dl_manager.download_and_extract([_URLS["test"].format(lang=LANGUAGES_MAP[lang]) for lang in LANGUAGES_MAP])
+        else:
+            lang = self.config.name[12:15]
+            train_csv_path = Path(dl_manager.download_and_extract(_URLS["train"].format(lang=LANGUAGES_MAP[lang])))
+            validation_csv_path = Path(dl_manager.download_and_extract(_URLS["validation"].format(lang=LANGUAGES_MAP[lang])))
+            test_csv_path = Path(dl_manager.download_and_extract(_URLS["test"].format(lang=LANGUAGES_MAP[lang])))
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"filepath": train_csv_path},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={"filepath": validation_csv_path},
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={"filepath": test_csv_path},
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        if self.config.schema != "source" and self.config.schema != "nusantara_text":
+            raise ValueError(f"Invalid config: {self.config.name}")
+
+        if self.config.name == "nusax_senti_source" or self.config.name == "nusax_senti_nusantara_text":
+            ldf = []
+            for fp in filepath:
+                ldf.append(pd.read_csv(fp))
+            df = pd.concat(ldf, axis=0, ignore_index=True).reset_index()
+            # Have to use index instead of id to avoid duplicated key
+            df = df.drop(columns=["id"]).rename(columns={"index": "id"})
+        else:
+            df = pd.read_csv(filepath).reset_index()
+
+        for row in df.itertuples():
+            ex = {"id": str(row.id), "text": row.text, "label": row.label}
+            yield row.id, ex

--- a/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
+++ b/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
@@ -101,14 +101,14 @@ class IndoPuisi(datasets.GeneratorBasedBuilder):
             for row in df.itertuples():
                 ex = {
                     "id": str(row.index),
-                    "puisi": row.puisi,
+                    "puisi": str(row.puisi).rstrip(),
                     "title": row.title,
                     "author": row.author,
-                    "puisi_with_header": row.puisi_with_header,
+                    "puisi_with_header": str(row.puisi_with_header).rstrip(),
                 }
                 yield row.index, ex
 
         elif self.config.name == "indo_puisi_nusantara_ssp":
             for row in df.itertuples():
-                ex = {"id": str(row.index), "text": row.puisi}
+                ex = {"id": str(row.index), "text": str(row.puisi).rstrip()}
                 yield row.index, ex

--- a/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
+++ b/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
@@ -100,14 +100,14 @@ class IndoPuisi(datasets.GeneratorBasedBuilder):
         if self.config.name == "indo_puisi_source":
             for row in df.itertuples():
                 ex = {
-                    "id": str(row.index), 
+                    "id": str(row.index),
                     "puisi": row.puisi,
                     "title": row.title,
                     "author": row.author,
                     "puisi_with_header": row.puisi_with_header,
-                    }
+                }
                 yield row.index, ex
-            
+
         elif self.config.name == "indo_puisi_nusantara_ssp":
             for row in df.itertuples():
                 ex = {"id": str(row.index), "text": row.puisi}

--- a/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
+++ b/nusantara/nusa_datasets/indo_puisi/indo_puisi.py
@@ -17,6 +17,7 @@ _CITATION = """
 """
 
 _DESCRIPTION = """\
+Puisi is an Indonesian poetic form. The dataset was collected by scraping various websites. It contains 7223 Indonesian puisi along with the title and author.
 """
 
 _HOMEPAGE = "https://github.com/ilhamfp/puisi-pantun-generator"
@@ -30,61 +31,18 @@ _SOURCE_VERSION = "1.0.0"
 _NUSANTARA_VERSION = "1.0.0"
 
 _URLS = {
-    "train": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/sentiment/{lang}/train.csv",
-    "validation": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/sentiment/{lang}/valid.csv",
-    "test": "https://raw.githubusercontent.com/IndoNLP/nusax/main/datasets/sentiment/{lang}/test.csv",
+    "train": "https://github.com/ilhamfp/puisi-pantun-generator/blob/main/data/puisi.csv",
 }
 
 
-def nusantara_config_constructor(lang, schema, version):
-    """Construct NusantaraConfig with nusax_senti_{lang}_{schema} as the name format"""
-    if schema != "source" and schema != "nusantara_text":
-        raise ValueError(f"Invalid schema: {schema}")
-
-    if lang == "":
-        return NusantaraConfig(
-            name="nusax_senti_{schema}".format(schema=schema),
-            version=datasets.Version(version),
-            description="nusax_senti with {schema} schema for all 12 languages".format(schema=schema),
-            schema=schema,
-            subset_id="nusax_senti",
-        )
-    else:
-        return NusantaraConfig(
-            name="nusax_senti_{lang}_{schema}".format(lang=lang, schema=schema),
-            version=datasets.Version(version),
-            description="nusax_senti with {schema} schema for {lang} language".format(lang=lang, schema=schema),
-            schema=schema,
-            subset_id="nusax_senti",
-        )
-
-
-LANGUAGES_MAP = {
-    "ace": "acehnese",
-    "ban": "balinese",
-    "bjn": "banjarese",
-    "bug": "buginese",
-    "eng": "english",
-    "ind": "indonesian",
-    "jav": "javanese",
-    "mad": "madurese",
-    "min": "minangkabau",
-    "nij": "ngaju",
-    "sun": "sundanese",
-    "bbc": "toba_batak",
-}
-
-
-class NusaXSenti(datasets.GeneratorBasedBuilder):
-    """NusaX-Senti is a 3-labels (positive, neutral, negative) sentiment analysis dataset for 10 Indonesian local languages + Indonesian and English."""
+class IndoPuisi(datasets.GeneratorBasedBuilder):
+    """IndoPuisi contains 7223 Indonesian puisi along with the title and author."""
 
     BUILDER_CONFIGS = (
         [nusantara_config_constructor(lang, "source", _SOURCE_VERSION) for lang in LANGUAGES_MAP]
-        + [nusantara_config_constructor(lang, "nusantara_text", _NUSANTARA_VERSION) for lang in LANGUAGES_MAP]
-        + [nusantara_config_constructor("", "source", _SOURCE_VERSION), nusantara_config_constructor("", "nusantara_text", _NUSANTARA_VERSION)]
     )
 
-    DEFAULT_CONFIG_NAME = "nusax_senti_ind_source"
+    DEFAULT_CONFIG_NAME = "indo_puisi_source"
 
     def _info(self) -> datasets.DatasetInfo:
         if self.config.schema == "source":


### PR DESCRIPTION
Add Indo Puisi Dataloader 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
