### PR TITLE
Closes #156 | Implement kamus alay dataset loader

### DIFF
--- a/nusantara/nusa_datasets/kamus_alay/kamus_alay.py
+++ b/nusantara/nusa_datasets/kamus_alay/kamus_alay.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks
+from nusantara.utils import schemas
+
+import pandas as pd
+
+
+_CITATION = """\
+@INPROCEEDINGS{8629151,
+author={Aliyah Salsabila, Nikmatun and Ardhito Winatmoko, Yosef and Akbar Septiandri, Ali and Jamal, Ade},
+booktitle={2018 International Conference on Asian Language Processing (IALP)},
+title={Colloquial Indonesian Lexicon},
+year={2018},
+volume={},
+number={},
+pages={226-229},
+doi={10.1109/IALP.2018.8629151}}
+"""
+
+_DATASETNAME = "kamus_alay"
+
+_DESCRIPTION = """\
+Kamus Alay provide a lexicon for text normalization of Indonesian colloquial words.
+It contains 3,592 unique colloquial words-also known as “bahasa alay” -and manually annotated them
+with the normalized form. We built this lexicon from Instagram comments provided by Septiandri & Wibisono (2017)
+"""
+
+_HOMEPAGE = "https://ieeexplore.ieee.org/abstract/document/8629151"
+
+_LICENSE = "Unknown"
+
+_URLS = {
+    _DATASETNAME: "https://raw.githubusercontent.com/nasalsabila/kamus-alay/master/colloquial-indonesian-lexicon.csv",
+}
+
+_SUPPORTED_TASKS = [Tasks.PARAPHRASING]
+
+# Dataset does not have versioning
+_SOURCE_VERSION = "1.0.0"
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class KamusAlay(datasets.GeneratorBasedBuilder):
+    """Kamus Alay is a dataset of lexicon for text normalization of Indonesian colloquial word
+    """
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="kamus_alay_source",
+            version=SOURCE_VERSION,
+            description="Kamus Alay source schema",
+            schema="source",
+            subset_id="kamus_alay",
+        ),
+        NusantaraConfig(
+            name="kamus_alay_nusantara_t2t",
+            version=NUSANTARA_VERSION,
+            description="Kamus Alay Nusantara schema",
+            schema="nusantara_t2t",
+            subset_id="kamus_alay",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "kamus_alay_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+          features = datasets.Features(
+            {
+              "slang": datasets.Value("string"),
+              "formal": datasets.Value("string"),
+              "is_in_dictionary": datasets.Value("bool"),
+              "example": datasets.Value("string"),
+            }
+          )
+        elif self.config.schema == "nusantara_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        urls = _URLS[_DATASETNAME]
+
+        data_dir = Path(dl_manager.download(urls))
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # Dataset does not have id, using row index as id
+        df = pd.read_csv(filepath, encoding="ISO-8859-1").reset_index()
+        df.columns = ["id", "slang", "formal", "is_in_dictionary", "example", "category1", "category2", "category3"]
+
+        if self.config.schema == "source":
+            for row in df.itertuples():
+                ex = {
+                    "slang": row.slang,
+                    "formal": row.formal,
+                    "is_in_dictionary": row.is_in_dictionary,
+                    "example": row.example
+                }
+                yield row.id, ex
+
+        elif self.config.schema == "nusantara_t2t":
+            for row in df.itertuples():
+                ex = {
+                    "id": str(row.id),
+                    "text_1": row.slang,
+                    "text_2": row.formal,
+                    "text_1_name": "slang",
+                    "text_2_name": "formal"
+                }
+                yield row.id, ex
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")


### PR DESCRIPTION
### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [X] Confirm dataloader script works with `datasets.load_dataset` function.
- [X] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [X] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

```
INFO:__main__:args: Namespace(path='nusantara/nusa_datasets/kamus_alay/kamus_alay.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: nusantara/nusa_datasets/kamus_alay/kamus_alay.py
INFO:__main__:self.SUBSET_ID: kamus_alay
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module nusantara.nusa_datasets.kamus_alay.kamus_alay
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.PARAPHRASING: 'PARA'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'T2T'}
INFO:__main__:schemas_to_check: {'T2T'}
INFO:__main__:Checking load_dataset with config name kamus_alay_source
Downloading and preparing dataset kamus_alay/kamus_alay_source to /Users/christianwbsn/.cache/huggingface/datasets/kamus_alay/kamus_alay_source/1.0.0/01ed3d791d194b2fe55784159b4db8d95499123a9b073b7cf5f8ae5610bbdccc...
Dataset kamus_alay downloaded and prepared to /Users/christianwbsn/.cache/huggingface/datasets/kamus_alay/kamus_alay_source/1.0.0/01ed3d791d194b2fe55784159b4db8d95499123a9b073b7cf5f8ae5610bbdccc. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 622.95it/s]
INFO:__main__:Checking load_dataset with config name kamus_alay_nusantara_t2t
Downloading and preparing dataset kamus_alay/kamus_alay_nusantara_t2t to /Users/christianwbsn/.cache/huggingface/datasets/kamus_alay/kamus_alay_nusantara_t2t/1.0.0/01ed3d791d194b2fe55784159b4db8d95499123a9b073b7cf5f8ae5610bbdccc...
Dataset kamus_alay downloaded and prepared to /Users/christianwbsn/.cache/huggingface/datasets/kamus_alay/kamus_alay_nusantara_t2t/1.0.0/01ed3d791d194b2fe55784159b4db8d95499123a9b073b7cf5f8ae5610bbdccc. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 717.22it/s]
WARNING:datasets.builder:Reusing dataset kamus_alay (/Users/christianwbsn/.cache/huggingface/datasets/kamus_alay/kamus_alay_source/1.0.0/01ed3d791d194b2fe55784159b4db8d95499123a9b073b7cf5f8ae5610bbdccc)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 813.80it/s]
INFO:__main__:Dataset sample [source]
{'slang': 'woww', 'formal': 'wow', 'is_in_dictionary': True, 'example': 'wow'}
WARNING:datasets.builder:Reusing dataset kamus_alay (/Users/christianwbsn/.cache/huggingface/datasets/kamus_alay/kamus_alay_nusantara_t2t/1.0.0/01ed3d791d194b2fe55784159b4db8d95499123a9b073b7cf5f8ae5610bbdccc)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 858.43it/s]
INFO:__main__:Dataset sample [nusantara_t2t]
{'id': '0', 'text_1': 'woww', 'text_2': 'wow', 'text_1_name': 'slang', 'text_2_name': 'formal'}
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 15006 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 15006
text_1: 15006
text_2: 15006
text_1_name: 15006
text_2_name: 15006

.
----------------------------------------------------------------------
Ran 1 test in 4.505s
```
