### PR TITLE
Closes #37 | Implement Inset lexicon dataset loader

### DIFF
--- a/nusantara/nusa_datasets/inset_lexicon/inset_lexicon.py
+++ b/nusantara/nusa_datasets/inset_lexicon/inset_lexicon.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+import pandas as pd
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks
+
+_CITATION = """\
+@inproceedings{inproceedings,
+author = {Koto, Fajri and Rahmaningtyas, Gemala},
+year = {2017},
+month = {12},
+pages = {},
+title = {InSet Lexicon: Evaluation of a Word List for Indonesian Sentiment Analysis in Microblogs},
+doi = {10.1109/IALP.2017.8300625}
+}
+"""
+
+_DATASETNAME = "inset_lexicon"
+
+_DESCRIPTION = """\
+InSet, an Indonesian sentiment lexicon built to identify written opinion and categorize it into positive or negative opinion,
+which could be utilized to analyze public sentiment towards particular topic, event, or product. Composed using collection
+of words from Indonesian tweet, InSet was constructed by manually weighting each words and enhanced by adding stemming and synonym set
+"""
+
+_HOMEPAGE = "https://www.researchgate.net/publication/321757985_InSet_Lexicon_Evaluation_of_a_Word_List_for_Indonesian_Sentiment_Analysis_in_Microblogs"
+_LICENSE = "Unknown"
+_URLS = {
+    _DATASETNAME: "https://github.com/fajri91/InSet/archive/refs/heads/master.zip"
+}
+_SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS]
+_SOURCE_VERSION = "1.0.0"
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class InsetLexicon(datasets.GeneratorBasedBuilder):
+    """InSet, an Indonesian sentiment lexicon built to identify written opinion and categorize it into positive or negative opinion"""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="inset_lexicon_source",
+            version=SOURCE_VERSION,
+            description="Inset Lexicon source schema",
+            schema="source",
+            subset_id="inset_lexicon",
+        ),
+        NusantaraConfig(
+            name="inset_lexicon_nusantara_text",
+            version=NUSANTARA_VERSION,
+            description="Inset Lexicon Nusantara schema",
+            schema="nusantara_text",
+            subset_id="inset_lexicon",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "inset_lexicon_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+        if self.config.schema == "source":
+            features = datasets.Features({"word": datasets.Value("string"), "weight": datasets.Value("string")})
+        elif self.config.schema == "nusantara_text":
+            labels = list(range(-5, 6, 1))
+            labels = [str(label) for label in labels]
+            features = schemas.text_features(labels)
+
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+        # Dataset does not have predetermined split, putting all as TRAIN
+        urls = _URLS[_DATASETNAME]
+        base_dir = Path(dl_manager.download_and_extract(urls)) / "InSet-master" 
+        positive_df = pd.read_csv(base_dir / "positive.tsv", sep="\t")
+        negative_df = pd.read_csv(base_dir / "negative.tsv", sep ="\t")
+        merged_df = pd.concat([positive_df, negative_df]).reset_index(drop=True)
+        merged_data_dir = base_dir / "dataset.tsv"
+        merged_df.to_csv(merged_data_dir, sep="\t")
+
+        data_files = {"train": merged_data_dir}
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_files["train"],
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path, split: str) -> Tuple[int, Dict]:
+        """Yields examples as (key, example) tuples."""
+        # Dataset does not have id, using row index as id
+        df = pd.read_csv(filepath, sep="\t", encoding="ISO-8859-1")
+        df.columns = ["id", "word", "weight"]
+
+        if self.config.schema == "source":
+            for row in df.itertuples():
+                ex = {
+                    "word": row.word,
+                    "weight": str(int(row.weight)),
+                }
+                yield row.id, ex
+
+        elif self.config.schema == "nusantara_text":
+            for row in df.itertuples():
+                ex = {
+                    "id": str(row.id),
+                    "text": row.word,
+                    "label": str(int(row.weight)),
+                }
+                yield row.id, ex
+        else:
+            raise ValueError(f"Invalid config: {self.config.name}")

--- a/nusantara/nusa_datasets/inset_lexicon/inset_lexicon.py
+++ b/nusantara/nusa_datasets/inset_lexicon/inset_lexicon.py
@@ -29,9 +29,8 @@ of words from Indonesian tweet, InSet was constructed by manually weighting each
 
 _HOMEPAGE = "https://www.researchgate.net/publication/321757985_InSet_Lexicon_Evaluation_of_a_Word_List_for_Indonesian_Sentiment_Analysis_in_Microblogs"
 _LICENSE = "Unknown"
-_URLS = {
-    _DATASETNAME: "https://github.com/fajri91/InSet/archive/refs/heads/master.zip"
-}
+_URLS = {_DATASETNAME: "https://github.com/fajri91/InSet/archive/refs/heads/master.zip"}
+
 _SUPPORTED_TASKS = [Tasks.SENTIMENT_ANALYSIS]
 _SOURCE_VERSION = "1.0.0"
 _NUSANTARA_VERSION = "1.0.0"
@@ -70,7 +69,6 @@ class InsetLexicon(datasets.GeneratorBasedBuilder):
             labels = [str(label) for label in labels]
             features = schemas.text_features(labels)
 
-
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
             features=features,
@@ -83,9 +81,9 @@ class InsetLexicon(datasets.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
         # Dataset does not have predetermined split, putting all as TRAIN
         urls = _URLS[_DATASETNAME]
-        base_dir = Path(dl_manager.download_and_extract(urls)) / "InSet-master" 
+        base_dir = Path(dl_manager.download_and_extract(urls)) / "InSet-master"
         positive_df = pd.read_csv(base_dir / "positive.tsv", sep="\t")
-        negative_df = pd.read_csv(base_dir / "negative.tsv", sep ="\t")
+        negative_df = pd.read_csv(base_dir / "negative.tsv", sep="\t")
         merged_df = pd.concat([positive_df, negative_df]).reset_index(drop=True)
         merged_data_dir = base_dir / "dataset.tsv"
         merged_df.to_csv(merged_data_dir, sep="\t")


### PR DESCRIPTION
### Checkbox
- [X] Confirm that this PR is linked to the dataset issue.
- [X] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [X] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [X] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [X] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [X] Confirm dataloader script works with `datasets.load_dataset` function.
- [X] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [X] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

```
INFO:__main__:args: Namespace(path='nusantara/nusa_datasets/inset_lexicon/inset_lexicon.py', schema=None, subset_id=None, data_dir=None, use_auth_token=None)
INFO:__main__:self.PATH: nusantara/nusa_datasets/inset_lexicon/inset_lexicon.py
INFO:__main__:self.SUBSET_ID: inset_lexicon
INFO:__main__:self.SCHEMA: None
INFO:__main__:self.DATA_DIR: None
INFO:__main__:Checking for _SUPPORTED_TASKS ...
module nusantara.nusa_datasets.inset_lexicon.inset_lexicon
INFO:__main__:Found _SUPPORTED_TASKS=[<Tasks.SENTIMENT_ANALYSIS: 'SA'>]
INFO:__main__:_SUPPORTED_TASKS implies _MAPPED_SCHEMAS={'TEXT'}
INFO:__main__:schemas_to_check: {'TEXT'}
INFO:__main__:Checking load_dataset with config name inset_lexicon_source
Downloading and preparing dataset inset_lexicon/inset_lexicon_source to /Users/christianwbsn/.cache/huggingface/datasets/inset_lexicon/inset_lexicon_source/1.0.0/07d96167b0ff0e43da0eafa42f2a5e32ed38c8bc867ea030561a864ae988c234...
Dataset inset_lexicon downloaded and prepared to /Users/christianwbsn/.cache/huggingface/datasets/inset_lexicon/inset_lexicon_source/1.0.0/07d96167b0ff0e43da0eafa42f2a5e32ed38c8bc867ea030561a864ae988c234. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 273.23it/s]
INFO:__main__:Checking load_dataset with config name inset_lexicon_nusantara_text
Downloading and preparing dataset inset_lexicon/inset_lexicon_nusantara_text to /Users/christianwbsn/.cache/huggingface/datasets/inset_lexicon/inset_lexicon_nusantara_text/1.0.0/07d96167b0ff0e43da0eafa42f2a5e32ed38c8bc867ea030561a864ae988c234...
Dataset inset_lexicon downloaded and prepared to /Users/christianwbsn/.cache/huggingface/datasets/inset_lexicon/inset_lexicon_nusantara_text/1.0.0/07d96167b0ff0e43da0eafa42f2a5e32ed38c8bc867ea030561a864ae988c234. Subsequent calls will reuse this data.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 809.71it/s]
WARNING:datasets.builder:Reusing dataset inset_lexicon (/Users/christianwbsn/.cache/huggingface/datasets/inset_lexicon/inset_lexicon_source/1.0.0/07d96167b0ff0e43da0eafa42f2a5e32ed38c8bc867ea030561a864ae988c234)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 869.65it/s]
INFO:__main__:Dataset sample [source]
{'word': 'hai', 'weight': '3'}
WARNING:datasets.builder:Reusing dataset inset_lexicon (/Users/christianwbsn/.cache/huggingface/datasets/inset_lexicon/inset_lexicon_nusantara_text/1.0.0/07d96167b0ff0e43da0eafa42f2a5e32ed38c8bc867ea030561a864ae988c234)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 856.85it/s]
INFO:__main__:Dataset sample [nusantara_text]
{'id': '0', 'text': 'hai', 'label': 8}
INFO:__main__:Checking global ID uniqueness
INFO:__main__:Found 10218 unique IDs
INFO:__main__:Gathering schema statistics
INFO:__main__:Gathering schema statistics
train
==========
id: 10218
text: 10218
label: 10218

.
----------------------------------------------------------------------
Ran 1 test in 3.088s

OK
```