### PR TITLE
Add ImageText schema and tasks (IC, SIC, VGR)

### DIFF
--- a/nusantara/utils/constants.py
+++ b/nusantara/utils/constants.py
@@ -48,6 +48,11 @@ class Tasks(Enum):
     # Speech Recognition
     SPEECH_RECOGNITION = "ASR"
 
+    # ImageText
+    IMAGE_CAPTIONING = "IC"
+    STYLIZED_IMAGE_CAPTIONING = "SIC"
+    VISUALLY_GROUNDED_REASONING = "VGR"
+
 
 # TASK_TO_SCHEMA = {
 #     Tasks.NAMED_ENTITY_RECOGNITION: "KB",

--- a/nusantara/utils/schemas/__init__.py
+++ b/nusantara/utils/schemas/__init__.py
@@ -8,5 +8,6 @@ from .text_to_text import features as text2text_features
 from .seq_label import features as seq_label_features
 from .self_supervised_pretraining import features as ssp_features
 from .speech_recognition import features as asr_features
+from .image_text import features as image_text_features
 
-__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "pairs_features_score", "seq_label_features", "ssp_features", "asr_features"]
+__all__ = ["kb_features", "qa_features", "text2text_features", "text_features", "text_multi_features", "pairs_features", "pairs_features_score", "seq_label_features", "ssp_features", "asr_features", "image_text_features"]

--- a/nusantara/utils/schemas/image_text.py
+++ b/nusantara/utils/schemas/image_text.py
@@ -1,0 +1,18 @@
+"""
+General ImageText Classification Schema
+"""
+import datasets
+
+def features(label_names = ["Yes", "No"]):
+    return datasets.Features(
+        {
+            "id": datasets.Value("string"),
+            "image_paths": datasets.Sequence(datasets.Value("string")),
+            "texts": datasets.Value("string"),
+            "metadata": {
+                "context": datasets.Value("string"),
+                "labels": datasets.Sequence(datasets.ClassLabel(names=label_names)),
+            }
+        }
+    )
+

--- a/tests/test_nusantara.py
+++ b/tests/test_nusantara.py
@@ -12,7 +12,7 @@ from typing import Iterable, Iterator, List, Optional, Union, Dict
 import datasets
 from datasets import DatasetDict, Features
 from nusantara.utils.constants import Tasks
-from nusantara.utils.schemas import kb_features, pairs_features, pairs_features_score, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features, asr_features
+from nusantara.utils.schemas import kb_features, pairs_features, pairs_features_score, qa_features, text2text_features, text_features, text_multi_features, seq_label_features, ssp_features, asr_features, image_text_features
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -43,6 +43,9 @@ _TASK_TO_SCHEMA = {
     Tasks.EMOTION_CLASSIFICATION: "TEXT",
     Tasks.SELF_SUPERVISED_PRETRAINING: "SSP",
     Tasks.SPEECH_RECOGNITION: "ASR",
+    Tasks.IMAGE_CAPTIONING: "IC",
+    Tasks.STYLIZED_IMAGE_CAPTIONING: "SIC",
+    Tasks.VISUALLY_GROUNDED_REASONING: "VGR",
 }
 
 _VALID_TASKS = set(_TASK_TO_SCHEMA.keys())
@@ -59,6 +62,9 @@ _SCHEMA_TO_FEATURES = {
     "SEQ_LABEL": seq_label_features(),
     "SSP": ssp_features,
     "ASR": asr_features,
+    "IC": image_text_features(),
+    "SIC": image_text_features(),
+    "VGR": image_text_features(),
 }
 
 _TASK_TO_FEATURES = {


### PR DESCRIPTION
ImageText schema is constructed with [MaRVL](https://indonlp.github.io/nusa-catalogue/card.html?marvl) (#165) and [COCO Captions ID](https://indonlp.github.io/nusa-catalogue/card.html?coco_caption_id) (#113) datasets in mind.