### PR TITLE
Close #130 | Create dataset loader for ID_Quora_Paraphrasing dataset

### DIFF
--- a/nusantara/nusa_datasets/id_qqp/id_qqp.py
+++ b/nusantara/nusa_datasets/id_qqp/id_qqp.py
@@ -14,8 +14,8 @@ _CITATION = """\
 	author = {},
 	title = {{F}irst {Q}uora {D}ataset {R}elease: {Q}uestion {P}airs --- quoradata.quora.com},
 	howpublished = {\url{https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs}},
-	year = {},
-	note = {[Accessed DD-MM-YYYY]},
+	year = 2017,
+	note = {Online},
 }
 """
 

--- a/nusantara/nusa_datasets/id_qqp/id_qqp.py
+++ b/nusantara/nusa_datasets/id_qqp/id_qqp.py
@@ -10,14 +10,22 @@ from nusantara.utils import schemas
 import json
 
 _CITATION = """\
-    https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs
+@misc{quoraFirstQuora,
+	author = {},
+	title = {{F}irst {Q}uora {D}ataset {R}elease: {Q}uestion {P}airs --- quoradata.quora.com},
+	howpublished = {\url{https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs}},
+	year = {},
+	note = {[Accessed DD-MM-YYYY]},
+}
 """
 
 _DATASETNAME = "id_qqp"
 
 _DESCRIPTION = """\
-INDOSUM is a new benchmark dataset for Indonesian text summarization. 
-The dataset consists of news articles and manually constructed summaries.
+Quora Question Pairs (QQP) dataset consists of over 400,000 question pairs, 
+and each question pair is annotated with a binary value indicating whether 
+the two questions are paraphrase of each other. This dataset is translated 
+version of QQP to Indonesian Language.
 """
 
 _HOMEPAGE = "https://github.com/louisowen6/quora_paraphrasing_id"
@@ -38,8 +46,13 @@ _SOURCE_VERSION = "1.0.0"
 _NUSANTARA_VERSION = "1.0.0"
 
 
-class IndoSUM(datasets.GeneratorBasedBuilder):
-    """INDOSUM is a new benchmark dataset for Indonesian text summarization. The dataset consists of news articles and manually constructed summaries."""
+class IdQuoraQuestionPairs(datasets.GeneratorBasedBuilder):
+    """
+    Quora Question Pairs (QQP) dataset consists of over 400,000 question pairs, 
+    and each question pair is annotated with a binary value indicating whether 
+    the two questions are paraphrase of each other. This dataset is translated 
+    version of QQP to Indonesian Language.
+    """
 
     SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
     NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)

--- a/nusantara/nusa_datasets/id_qqp/id_qqp.py
+++ b/nusantara/nusa_datasets/id_qqp/id_qqp.py
@@ -13,7 +13,7 @@ _CITATION = """\
 @misc{quoraFirstQuora,
 	author = {},
 	title = {{F}irst {Q}uora {D}ataset {R}elease: {Q}uestion {P}airs --- quoradata.quora.com},
-	howpublished = {\url{https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs}},
+	howpublished = {https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs},
 	year = 2017,
 	note = {Online},
 }

--- a/nusantara/nusa_datasets/id_qqp/id_qqp.py
+++ b/nusantara/nusa_datasets/id_qqp/id_qqp.py
@@ -1,0 +1,137 @@
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import datasets
+
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import Tasks
+from nusantara.utils import schemas
+import json
+
+_CITATION = """\
+    https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs
+"""
+
+_DATASETNAME = "id_qqp"
+
+_DESCRIPTION = """\
+INDOSUM is a new benchmark dataset for Indonesian text summarization. 
+The dataset consists of news articles and manually constructed summaries.
+"""
+
+_HOMEPAGE = "https://github.com/louisowen6/quora_paraphrasing_id"
+
+_LICENSE = "Apache License, Version 2.0"
+
+_URLS = {
+    _DATASETNAME: [
+        "https://github.com/louisowen6/quora_paraphrasing_id/raw/main/ID_Quora_Paraphrasing_train.json",
+        "https://github.com/louisowen6/quora_paraphrasing_id/raw/main/ID_Quora_Paraphrasing_val.json",
+    ]
+}
+
+_SUPPORTED_TASKS = [Tasks.PARAPHRASING]
+
+_SOURCE_VERSION = "1.0.0"
+
+_NUSANTARA_VERSION = "1.0.0"
+
+
+class IndoSUM(datasets.GeneratorBasedBuilder):
+    """INDOSUM is a new benchmark dataset for Indonesian text summarization. The dataset consists of news articles and manually constructed summaries."""
+
+    SOURCE_VERSION = datasets.Version(_SOURCE_VERSION)
+    NUSANTARA_VERSION = datasets.Version(_NUSANTARA_VERSION)
+    
+    BUILDER_CONFIGS = [
+        NusantaraConfig(
+            name="id_qqp_source",
+            version=SOURCE_VERSION,
+            description="ID QQP source schema",
+            schema="source",
+            subset_id="id_qqp",
+        ),
+        NusantaraConfig(
+            name="id_qqp_nusantara_t2t",
+            version=NUSANTARA_VERSION,
+            description="ID QQP Nusantara schema",
+            schema="nusantara_t2t",
+            subset_id="id_qqp",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "id_qqp_source"
+
+    def _info(self) -> datasets.DatasetInfo:
+
+        if self.config.schema == "source":
+
+            features = datasets.Features(
+               {
+                   "id": datasets.Value("string"),
+                   "question_1": datasets.Value("string"),
+                   "question_2": datasets.Value("string")
+               }
+            )
+
+        elif self.config.schema == "nusantara_t2t":
+            features = schemas.text2text_features
+
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+
+    def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
+        urls = _URLS[_DATASETNAME]
+        data_dir = dl_manager.download_and_extract(urls)
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": data_dir[0],
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": data_dir[1],
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepath: Path) -> Tuple[int, Dict]:
+        
+        with open(filepath, "r") as f:
+            lines = f.readlines()
+
+        if self.config.schema == "source":
+            
+            for i, line in enumerate(lines):
+                line = json.loads(line.strip())
+                
+                sample = {
+                    "id": str(i),
+                    "question_1": line["question_1"],
+                    "question_2": line["question_2"]
+                }
+                yield i, sample
+
+        elif self.config.schema == "nusantara_t2t":
+            
+            for i, line in enumerate(lines):
+                line = json.loads(line.strip())
+                
+                sample = {
+                    "id": str(i),
+                    "text_1": line["question_1"],
+                    "text_2": line["question_2"],
+                    "text_1_name": "question_1",
+                    "text_2_name": "question_2"
+                }
+                yield i, sample


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [x] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
