### PR TITLE
Close #215 | KoPI-CC Loader

### DIFF
--- a/nusantara/nusa_datasets/cc100/cc100.py
+++ b/nusantara/nusa_datasets/cc100/cc100.py
@@ -23,7 +23,9 @@ separated by double-newlines and paragraphs within the same document separated
 by a newline. The data is generated using the open source CC-Net repository. No
 claims of intellectual property are made on the work of preparation of the
 corpus.
+
 This contains the Indonesian (ind), the Javanese (jav), and the Sundanese (sun) subset.
+
 [nusantara_schema_name] = ssp
 """
 
@@ -82,6 +84,7 @@ _CITATION = """\
     is very competitive with strong monolingual models on the GLUE and XNLI
     benchmarks. We will make our code and models publicly available.",
 }
+
 @inproceedings{wenzek-etal-2020-ccnet,
     title = "{CCN}et: Extracting High Quality Monolingual Datasets from Web Crawl Data",
     author = "Wenzek, Guillaume  and

--- a/nusantara/nusa_datasets/cc100/cc100.py
+++ b/nusantara/nusa_datasets/cc100/cc100.py
@@ -187,16 +187,10 @@ class CC100(datasets.GeneratorBasedBuilder):
                     "text": datasets.Value("string"),
                 }
             )
-        elif self.config.schema == "nusantara_ssp":
+        elif self.config.schema == "nusa":
             features = schemas.self_supervised_pretraining.features
 
-        return datasets.DatasetInfo(
-            description=_DESCRIPTION,
-            features=features,
-            homepage=_HOMEPAGE,
-            license=_LICENSE,
-            citation=_CITATION,
-        )
+        a 
 
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""

--- a/nusantara/nusa_datasets/cc100/cc100.py
+++ b/nusantara/nusa_datasets/cc100/cc100.py
@@ -23,9 +23,7 @@ separated by double-newlines and paragraphs within the same document separated
 by a newline. The data is generated using the open source CC-Net repository. No
 claims of intellectual property are made on the work of preparation of the
 corpus.
-
 This contains the Indonesian (ind), the Javanese (jav), and the Sundanese (sun) subset.
-
 [nusantara_schema_name] = ssp
 """
 
@@ -84,7 +82,6 @@ _CITATION = """\
     is very competitive with strong monolingual models on the GLUE and XNLI
     benchmarks. We will make our code and models publicly available.",
 }
-
 @inproceedings{wenzek-etal-2020-ccnet,
     title = "{CCN}et: Extracting High Quality Monolingual Datasets from Web Crawl Data",
     author = "Wenzek, Guillaume  and
@@ -187,10 +184,16 @@ class CC100(datasets.GeneratorBasedBuilder):
                     "text": datasets.Value("string"),
                 }
             )
-        elif self.config.schema == "nusa":
+        elif self.config.schema == "nusantara_ssp":
             features = schemas.self_supervised_pretraining.features
 
-        a 
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
 
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""

--- a/nusantara/nusa_datasets/kopi-cc/kopi_cc.py
+++ b/nusantara/nusa_datasets/kopi-cc/kopi_cc.py
@@ -1,0 +1,348 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This corpus is an attempt to recreate the dataset used for training XLM-R. This
+corpus comprises of monolingual data for 100+ languages and also includes data
+for romanized languages (indicated by *_rom). This was constructed using the
+urls and paragraph indices provided by the CC-Net repository by processing
+January-December 2018 Commoncrawl snapshots. Each file comprises of documents
+separated by double-newlines and paragraphs within the same document separated
+by a newline. The data is generated using the open source CC-Net repository. No
+claims of intellectual property are made on the work of preparation of the
+corpus.
+
+This contains the Indonesian (ind), the Javanese (jav), and the Sundanese (sun) subset.
+
+[nusantara_schema_name] = ssp
+"""
+
+from posixpath import split
+from typing import Dict, List, Tuple
+
+import datasets
+import zstandard as zstd
+import json
+import gzip
+import os
+
+from nusantara.utils import schemas
+from nusantara.utils.configs import NusantaraConfig
+from nusantara.utils.constants import (DEFAULT_NUSANTARA_VIEW_NAME,
+                                       DEFAULT_SOURCE_VIEW_NAME, Tasks)
+
+_DATASETNAME = "kopi_cc"
+_SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
+_UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
+_URL = "https://commoncrawl.org/"
+_CITATION = """\
+        @inproceedings{conneau-etal-2020-unsupervised,
+    title = "Unsupervised Cross-lingual Representation Learning at Scale",
+    author = "Conneau, Alexis  and
+      Khandelwal, Kartikay  and
+      Goyal, Naman  and
+      Chaudhary, Vishrav  and
+      Wenzek, Guillaume  and
+      Guzm{'a}n, Francisco  and
+      Grave, Edouard  and
+      Ott, Myle  and
+      Zettlemoyer, Luke  and
+      Stoyanov, Veselin",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.acl-main.747",
+    doi = "10.18653/v1/2020.acl-main.747",
+    pages = "8440--8451",
+    abstract = "This paper shows that pretraining multilingual language models
+    at scale leads to significant performance gains for a wide range of
+    cross-lingual transfer tasks. We train a Transformer-based masked language
+    model on one hundred languages, using more than two terabytes of filtered
+    CommonCrawl data. Our model, dubbed XLM-R, significantly outperforms
+    multilingual BERT (mBERT) on a variety of cross-lingual benchmarks,
+    including +14.6{%} average accuracy on XNLI, +13{%} average F1 score on
+    MLQA, and +2.4{%} F1 score on NER. XLM-R performs particularly well on
+    low-resource languages, improving 15.7{%} in XNLI accuracy for Swahili and
+    11.4{%} for Urdu over previous XLM models. We also present a detailed
+    empirical analysis of the key factors that are required to achieve these
+    gains, including the trade-offs between (1) positive transfer and capacity
+    dilution and (2) the performance of high and low resource languages at
+    scale. Finally, we show, for the first time, the possibility of
+    multilingual modeling without sacrificing per-language performance; XLM-R
+    is very competitive with strong monolingual models on the GLUE and XNLI
+    benchmarks. We will make our code and models publicly available.",
+}
+
+@inproceedings{wenzek-etal-2020-ccnet,
+    title = "{CCN}et: Extracting High Quality Monolingual Datasets from Web Crawl Data",
+    author = "Wenzek, Guillaume  and
+      Lachaux, Marie-Anne  and
+      Conneau, Alexis  and
+      Chaudhary, Vishrav  and
+      Guzm{'a}n, Francisco  and
+      Joulin, Armand  and
+      Grave, Edouard",
+    booktitle = "Proceedings of the 12th Language Resources and Evaluation Conference",
+    month = may,
+    year = "2020",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://www.aclweb.org/anthology/2020.lrec-1.494",
+    pages = "4003--4012",
+    abstract = "Pre-training text representations have led to significant
+    improvements in many areas of natural language processing. The quality of
+    these models benefits greatly from the size of the pretraining corpora as
+    long as its quality is preserved. In this paper, we describe an automatic
+    pipeline to extract massive high-quality monolingual datasets from Common
+    Crawl for a variety of languages. Our pipeline follows the data processing
+    introduced in fastText (Mikolov et al., 2017; Grave et al., 2018), that
+    deduplicates documents and identifies their language. We augment this
+    pipeline with a filtering step to select documents that are close to high
+    quality corpora like Wikipedia.",
+    language = "English",
+    ISBN = "979-10-95546-34-4",
+}
+"""
+
+_DESCRIPTION = """\
+        This corpus is an attempt to recreate the dataset used for training
+        XLM-R. This corpus comprises of monolingual data for 100+ languages and
+        also includes data for romanized languages (indicated by *_rom). This
+        was constructed using the urls and paragraph indices provided by the
+        CC-Net repository by processing January-December 2018 Commoncrawl
+        snapshots. Each file comprises of documents separated by
+        double-newlines and paragraphs within the same document separated by a
+        newline. The data is generated using the open source CC-Net repository.
+        No claims of intellectual property are made on the work of preparation
+        of the corpus.
+"""
+
+_HOMEPAGE = ""
+
+_LICENSE = "CC0"
+
+_URLS = {
+    "raw":"https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/raw/id_meta_{index}.jsonl.zst",
+    "dedup": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/dedup/oscar-{index:012d}.json.gz",
+    "neardup": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/neardup/oscar-neardup-{index:012d}.json.gz",
+    "neardup_clean": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/neardup_clean/cleaned_oscar-neardup-{index:012d}.json.gz"
+}
+
+
+_N_SHARDS_PER_SNAPSHOT = {
+    "2021_10": {
+        "dedup":132,
+        "neardup":120,
+        "neardup_clean":120
+    },
+    "2021_17": {
+        "raw":31,
+        "dedup":47,
+        "neardup":41,
+        "neardup_clean":41
+    },
+    "2021_21":{
+        "raw":63,
+        "dedup":37,
+        "neardup":33,
+        "neardup_clean":33
+    },
+    "2021_25":{
+        "raw":31,
+        "dedup":32,
+        "neardup":28,
+        "neardup_clean":28
+    },
+    "2021_31":{
+        "raw":35,
+        "dedup":47,
+        "neardup":42,
+        "neardup_clean":42
+    },
+    "2021_39":{
+        "raw":35,
+        "dedup":44,
+        "neardup":38,
+        "neardup_clean":38
+    },
+    "2021_43":{
+        "raw":35,
+        "dedup":44,
+        "neardup":39,
+        "neardup_clean":39
+    },
+    "2021_49":{
+        "dedup":31,
+        "neardup":28,
+        "neardup_clean":28
+    },
+    "2022_05":{
+        "raw":40,
+        "dedup":18,
+        "neardup":18,
+        "neardup_clean":35
+    },
+    "2022_21":{
+        "raw":40,
+        "dedup":42,
+        "neardup":37,
+        "neardup_clean":37
+    },
+    "2022_27":{
+        "raw":79,
+        "dedup":38,
+        "neardup":33,
+        "neardup_clean":33
+    }
+}
+
+_SNAP_CONFIG = []
+for m in list(_N_SHARDS_PER_SNAPSHOT.keys()):
+    ka = list(_N_SHARDS_PER_SNAPSHOT[m].keys())
+    conf = [m + "-" + a for a in ka]
+    _SNAP_CONFIG.extend(conf)
+_SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
+
+_ALL_CONFIG = ["all-raw","all-dedup","all-neardup","all-neardup_clean"] + _SNAP_CONFIG
+
+_SOURCE_VERSION = "2018.12.01"
+
+_NUSANTARA_VERSION = "1.0.0"
+
+def nusantara_config_constructor(snapshot, schema, version):
+    """Construct NusantaraConfig with cc100_{lang}_{schema} as the name format."""
+    if schema != "source" and schema != "nusa":
+        raise ValueError(f"Invalid schema: {schema}")
+
+    if snapshot == "":
+        raise ValueError(f"Snapshot is required. Choose one of these Snapshot: {_ALL_CONFIG}.")
+    elif snapshot in _SNAP_CONFIG + _ALL_CONFIG:
+        if schema == "nusa":
+            return NusantaraConfig(
+                name=f"{snapshot}-{schema}",
+                version=datasets.Version(version),
+                description=f"KoPI-CC with {schema} schema for {snapshot}",
+                schema=schema,
+                subset_id="KoPI-CC",
+            )
+        else:
+            return NusantaraConfig(
+                name=f"{snapshot}",
+                version=datasets.Version(version),
+                description=f"KoPI-CC with {schema} schema for {snapshot}",
+                schema=schema,
+                subset_id="KoPI-CC",
+            )
+    else:
+        raise ValueError(f"Invalid language: {snapshot}. Choose one of these snapshots: {_ALL_CONFIG}.")
+
+
+class KoPICC(datasets.GeneratorBasedBuilder):
+
+    BUILDER_CONFIGS = [
+        nusantara_config_constructor(sn, "source", _SOURCE_VERSION) for sn in _ALL_CONFIG
+    ] + [
+        nusantara_config_constructor(sn, "nusa", _NUSANTARA_VERSION) for sn in _ALL_CONFIG
+    ] 
+
+    def _info(self):
+        if self.config.schema == "source":
+            features=datasets.Features(
+                    {
+                        "text": datasets.Value("string"),
+                        "timestamp": datasets.Value("string"),
+                        "url": datasets.Value("string"),
+                        "meta": datasets.Value("string"),
+                    }
+                )
+        elif self.config.schema == "nusa":
+            features = schemas.self_supervised_pretraining.features
+            
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+
+    def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
+        """Returns SplitGenerators."""
+
+        split_name = self.config.name.split("-")
+        if split_name[0]== "all":
+            urls = []
+            keys = list(_N_SHARDS_PER_SNAPSHOT.keys())
+            idx = 0
+            if split_name[1] == "raw":
+                idx = 1
+                keys = [ur for ur in list(_N_SHARDS_PER_SNAPSHOT.keys()) if _N_SHARDS_PER_SNAPSHOT[ur].get('raw') is not None]
+            for m in keys:
+                urls.extend([_URLS[split_name[1]].format(snapshot=m,index=k+idx) for k in range(_N_SHARDS_PER_SNAPSHOT[m].get(split_name[1]))])
+        else:
+            urls = [_URLS[split_name[1]].format(snapshot=split_name[0],index=k+1) for k in range(_N_SHARDS_PER_SNAPSHOT[split_name[0]][split_name[1]])]
+        path = dl_manager.download(urls)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": path,
+                    "split": "train",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, filepaths):
+        """This function returns the examples in the raw (text) form by iterating on all the files."""
+        id_ = 0
+        filename, file_extension = os.path.splitext(filepaths)
+        for filepath in filepaths:
+            if file_extension == '.zst':
+                with zstd.open(open(filepath, "rb"), "rt", encoding="utf-8") as f:
+                    for line in f:
+                        if line:
+                            example = json.loads(line)
+                            meta = dict()
+                            meta["warc_headers"] = example["warc_headers"]
+                            meta["warc_headers"]["warc-identified-content-language"] = example[
+                                "warc_headers"
+                            ].get("warc-identified-content-language")
+                            meta["identification"] = example["metadata"]["identification"]
+                            meta["annotations"] = example["metadata"]["annotation"]
+                            meta["line_identifications"] = example["metadata"][
+                                "sentence_identifications"
+                            ]
+                            if self.config.schema == "nusa":
+                                yield id_, {"id":str(id_),'text':example['content']}
+                                id_ += 1
+                            else:
+                                yield id_, {'text':example['content'],'url':example['warc_headers']['warc-target-uri'],'timestamp':example['warc_headers']['warc-date'],"meta": json.dumps(meta)}
+                                id_ += 1
+            else:
+                with gzip.open(open(filepath, "rb"), "rt", encoding="utf-8") as f:
+                    for line in f:
+                        if line:
+                            example = json.loads(line)
+                            if self.config.schema == "nusa":
+                                yield id_, {"id":str(id_),'text':example['text']}
+                                id_ += 1
+                            else:
+                                yield id_, {'text':example['text'],'url':example['url'],'timestamp':example['timestamp'],'meta': example['meta']}
+                                id_ += 1
+        

--- a/nusantara/nusa_datasets/kopi-cc/kopi_cc.py
+++ b/nusantara/nusa_datasets/kopi-cc/kopi_cc.py
@@ -29,14 +29,12 @@ This contains the Indonesian (ind), the Javanese (jav), and the Sundanese (sun) 
 [nusantara_schema_name] = ssp
 """
 
-from posixpath import split
-from typing import Dict, List, Tuple
+import gzip
+import json
+from typing import List
 
 import datasets
 import zstandard as zstd
-import json
-import gzip
-import os
 
 from nusantara.utils import schemas
 from nusantara.utils.configs import NusantaraConfig
@@ -48,87 +46,41 @@ _SOURCE_VIEW_NAME = DEFAULT_SOURCE_VIEW_NAME
 _UNIFIED_VIEW_NAME = DEFAULT_NUSANTARA_VIEW_NAME
 _URL = "https://commoncrawl.org/"
 _CITATION = """\
-        @inproceedings{conneau-etal-2020-unsupervised,
-    title = "Unsupervised Cross-lingual Representation Learning at Scale",
-    author = "Conneau, Alexis  and
-      Khandelwal, Kartikay  and
-      Goyal, Naman  and
-      Chaudhary, Vishrav  and
-      Wenzek, Guillaume  and
-      Guzm{'a}n, Francisco  and
-      Grave, Edouard  and
-      Ott, Myle  and
-      Zettlemoyer, Luke  and
-      Stoyanov, Veselin",
-    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
-    month = jul,
-    year = "2020",
-    address = "Online",
-    publisher = "Association for Computational Linguistics",
-    url = "https://www.aclweb.org/anthology/2020.acl-main.747",
-    doi = "10.18653/v1/2020.acl-main.747",
-    pages = "8440--8451",
-    abstract = "This paper shows that pretraining multilingual language models
-    at scale leads to significant performance gains for a wide range of
-    cross-lingual transfer tasks. We train a Transformer-based masked language
-    model on one hundred languages, using more than two terabytes of filtered
-    CommonCrawl data. Our model, dubbed XLM-R, significantly outperforms
-    multilingual BERT (mBERT) on a variety of cross-lingual benchmarks,
-    including +14.6{%} average accuracy on XNLI, +13{%} average F1 score on
-    MLQA, and +2.4{%} F1 score on NER. XLM-R performs particularly well on
-    low-resource languages, improving 15.7{%} in XNLI accuracy for Swahili and
-    11.4{%} for Urdu over previous XLM models. We also present a detailed
-    empirical analysis of the key factors that are required to achieve these
-    gains, including the trade-offs between (1) positive transfer and capacity
-    dilution and (2) the performance of high and low resource languages at
-    scale. Finally, we show, for the first time, the possibility of
-    multilingual modeling without sacrificing per-language performance; XLM-R
-    is very competitive with strong monolingual models on the GLUE and XNLI
-    benchmarks. We will make our code and models publicly available.",
+       @ARTICLE{2022arXiv220106642A,
+       author = {{Abadji}, Julien and {Ortiz Suarez}, Pedro and {Romary}, Laurent and {Sagot}, Benoit},
+        title = "{Towards a Cleaner Document-Oriented Multilingual Crawled Corpus}",
+      journal = {arXiv e-prints},
+     keywords = {Computer Science - Computation and Language},
+         year = 2022,
+        month = jan,
+          eid = {arXiv:2201.06642},
+        pages = {arXiv:2201.06642},
+archivePrefix = {arXiv},
+       eprint = {2201.06642},
+ primaryClass = {cs.CL},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2022arXiv220106642A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@inproceedings{AbadjiOrtizSuarezRomaryetal.2021,
+  author    = {Julien Abadji and Pedro Javier Ortiz Su{\'a}rez and Laurent Romary and Benoit Sagot},
+  title     = {Ungoliant: An optimized pipeline for the generation of a very large-scale multilingual web corpus},
+  series = {Proceedings of the Workshop on Challenges in the Management of Large Corpora (CMLC-9) 2021. Limerick, 12 July 2021 (Online-Event)},
+  editor    = {Harald L{\"u}ngen and Marc Kupietz and Piotr Bański and Adrien Barbaresi and Simon Clematide and Ines Pisetta},
+  publisher = {Leibniz-Institut f{\"u}r Deutsche Sprache},
+  address   = {Mannheim},
+  doi       = {10.14618/ids-pub-10468},
+  url       = {https://nbn-resolving.org/urn:nbn:de:bsz:mh39-104688},
+  pages     = {1 -- 9},
+  year      = {2021},
+  abstract  = {Since the introduction of large language models in Natural Language Processing, large raw corpora have played a crucial role in Computational Linguistics.},
+  language  = {en}
 }
 
-@inproceedings{wenzek-etal-2020-ccnet,
-    title = "{CCN}et: Extracting High Quality Monolingual Datasets from Web Crawl Data",
-    author = "Wenzek, Guillaume  and
-      Lachaux, Marie-Anne  and
-      Conneau, Alexis  and
-      Chaudhary, Vishrav  and
-      Guzm{'a}n, Francisco  and
-      Joulin, Armand  and
-      Grave, Edouard",
-    booktitle = "Proceedings of the 12th Language Resources and Evaluation Conference",
-    month = may,
-    year = "2020",
-    address = "Marseille, France",
-    publisher = "European Language Resources Association",
-    url = "https://www.aclweb.org/anthology/2020.lrec-1.494",
-    pages = "4003--4012",
-    abstract = "Pre-training text representations have led to significant
-    improvements in many areas of natural language processing. The quality of
-    these models benefits greatly from the size of the pretraining corpora as
-    long as its quality is preserved. In this paper, we describe an automatic
-    pipeline to extract massive high-quality monolingual datasets from Common
-    Crawl for a variety of languages. Our pipeline follows the data processing
-    introduced in fastText (Mikolov et al., 2017; Grave et al., 2018), that
-    deduplicates documents and identifies their language. We augment this
-    pipeline with a filtering step to select documents that are close to high
-    quality corpora like Wikipedia.",
-    language = "English",
-    ISBN = "979-10-95546-34-4",
-}
 """
 
 _DESCRIPTION = """\
-        This corpus is an attempt to recreate the dataset used for training
-        XLM-R. This corpus comprises of monolingual data for 100+ languages and
-        also includes data for romanized languages (indicated by *_rom). This
-        was constructed using the urls and paragraph indices provided by the
-        CC-Net repository by processing January-December 2018 Commoncrawl
-        snapshots. Each file comprises of documents separated by
-        double-newlines and paragraphs within the same document separated by a
-        newline. The data is generated using the open source CC-Net repository.
-        No claims of intellectual property are made on the work of preparation
-        of the corpus.
+    KoPI-CC (Korpus Perayapan Indonesia)-CC is Indonesian Only Extract from Common Crawl snapshots ,each snapshots get extracted using ungoliant and get extra "filtering" using deduplication technique
+
 """
 
 _HOMEPAGE = ""
@@ -136,78 +88,25 @@ _HOMEPAGE = ""
 _LICENSE = "CC0"
 
 _URLS = {
-    "raw":"https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/raw/id_meta_{index}.jsonl.zst",
+    "raw": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/raw/id_meta_{index}.jsonl.zst",
     "dedup": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/dedup/oscar-{index:012d}.json.gz",
     "neardup": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/neardup/oscar-neardup-{index:012d}.json.gz",
-    "neardup_clean": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/neardup_clean/cleaned_oscar-neardup-{index:012d}.json.gz"
+    "neardup_clean": "https://huggingface.co/datasets/munggok/KoPI-CC/resolve/main/{snapshot}/neardup_clean/cleaned_oscar-neardup-{index:012d}.json.gz",
 }
 
 
 _N_SHARDS_PER_SNAPSHOT = {
-    "2021_10": {
-        "dedup":132,
-        "neardup":120,
-        "neardup_clean":120
-    },
-    "2021_17": {
-        "raw":31,
-        "dedup":47,
-        "neardup":41,
-        "neardup_clean":41
-    },
-    "2021_21":{
-        "raw":63,
-        "dedup":37,
-        "neardup":33,
-        "neardup_clean":33
-    },
-    "2021_25":{
-        "raw":31,
-        "dedup":32,
-        "neardup":28,
-        "neardup_clean":28
-    },
-    "2021_31":{
-        "raw":35,
-        "dedup":47,
-        "neardup":42,
-        "neardup_clean":42
-    },
-    "2021_39":{
-        "raw":35,
-        "dedup":44,
-        "neardup":38,
-        "neardup_clean":38
-    },
-    "2021_43":{
-        "raw":35,
-        "dedup":44,
-        "neardup":39,
-        "neardup_clean":39
-    },
-    "2021_49":{
-        "dedup":31,
-        "neardup":28,
-        "neardup_clean":28
-    },
-    "2022_05":{
-        "raw":40,
-        "dedup":18,
-        "neardup":18,
-        "neardup_clean":35
-    },
-    "2022_21":{
-        "raw":40,
-        "dedup":42,
-        "neardup":37,
-        "neardup_clean":37
-    },
-    "2022_27":{
-        "raw":79,
-        "dedup":38,
-        "neardup":33,
-        "neardup_clean":33
-    }
+    "2021_10": {"dedup": 132, "neardup": 120, "neardup_clean": 120},
+    "2021_17": {"raw": 31, "dedup": 47, "neardup": 41, "neardup_clean": 41},
+    "2021_21": {"raw": 63, "dedup": 37, "neardup": 33, "neardup_clean": 33},
+    "2021_25": {"raw": 31, "dedup": 32, "neardup": 28, "neardup_clean": 28},
+    "2021_31": {"raw": 35, "dedup": 47, "neardup": 42, "neardup_clean": 42},
+    "2021_39": {"raw": 35, "dedup": 44, "neardup": 38, "neardup_clean": 38},
+    "2021_43": {"raw": 35, "dedup": 44, "neardup": 39, "neardup_clean": 39},
+    "2021_49": {"dedup": 31, "neardup": 28, "neardup_clean": 28},
+    "2022_05": {"raw": 40, "dedup": 18, "neardup": 18, "neardup_clean": 35},
+    "2022_21": {"raw": 40, "dedup": 42, "neardup": 37, "neardup_clean": 37},
+    "2022_27": {"raw": 79, "dedup": 38, "neardup": 33, "neardup_clean": 33},
 }
 
 _SNAP_CONFIG = []
@@ -217,23 +116,24 @@ for m in list(_N_SHARDS_PER_SNAPSHOT.keys()):
     _SNAP_CONFIG.extend(conf)
 _SUPPORTED_TASKS = [Tasks.SELF_SUPERVISED_PRETRAINING]
 
-_ALL_CONFIG = ["all-raw","all-dedup","all-neardup","all-neardup_clean"] + _SNAP_CONFIG
+_ALL_CONFIG = ["all-raw", "all-dedup", "all-neardup", "all-neardup_clean"] + _SNAP_CONFIG
 
 _SOURCE_VERSION = "2018.12.01"
 
 _NUSANTARA_VERSION = "1.0.0"
 
+
 def nusantara_config_constructor(snapshot, schema, version):
-    """Construct NusantaraConfig with cc100_{lang}_{schema} as the name format."""
-    if schema != "source" and schema != "nusa":
+    """Construct NusantaraConfig"""
+    if schema != "source" and schema != "nusantara_ssp":
         raise ValueError(f"Invalid schema: {schema}")
 
     if snapshot == "":
         raise ValueError(f"Snapshot is required. Choose one of these Snapshot: {_ALL_CONFIG}.")
     elif snapshot in _SNAP_CONFIG + _ALL_CONFIG:
-        if schema == "nusa":
+        if schema == "nusantara_ssp":
             return NusantaraConfig(
-                name=f"{snapshot}-{schema}",
+                name=f"{snapshot}_{schema}",
                 version=datasets.Version(version),
                 description=f"KoPI-CC with {schema} schema for {snapshot}",
                 schema=schema,
@@ -241,7 +141,7 @@ def nusantara_config_constructor(snapshot, schema, version):
             )
         else:
             return NusantaraConfig(
-                name=f"{snapshot}",
+                name=f"{snapshot}_{schema}",
                 version=datasets.Version(version),
                 description=f"KoPI-CC with {schema} schema for {snapshot}",
                 schema=schema,
@@ -253,25 +153,23 @@ def nusantara_config_constructor(snapshot, schema, version):
 
 class KoPICC(datasets.GeneratorBasedBuilder):
 
-    BUILDER_CONFIGS = [
-        nusantara_config_constructor(sn, "source", _SOURCE_VERSION) for sn in _ALL_CONFIG
-    ] + [
-        nusantara_config_constructor(sn, "nusa", _NUSANTARA_VERSION) for sn in _ALL_CONFIG
-    ] 
+    DEFAULT_CONFIG_NAME = "2021_17_dedup"
+
+    BUILDER_CONFIGS = [nusantara_config_constructor(sn, "source", _SOURCE_VERSION) for sn in _ALL_CONFIG] + [nusantara_config_constructor(sn, "nusantara_ssp", _NUSANTARA_VERSION) for sn in _ALL_CONFIG]
 
     def _info(self):
         if self.config.schema == "source":
-            features=datasets.Features(
-                    {
-                        "text": datasets.Value("string"),
-                        "timestamp": datasets.Value("string"),
-                        "url": datasets.Value("string"),
-                        "meta": datasets.Value("string"),
-                    }
-                )
-        elif self.config.schema == "nusa":
+            features = datasets.Features(
+                {
+                    "text": datasets.Value("string"),
+                    "timestamp": datasets.Value("string"),
+                    "url": datasets.Value("string"),
+                    "meta": datasets.Value("string"),
+                }
+            )
+        elif self.config.schema == "nusantara_ssp":
             features = schemas.self_supervised_pretraining.features
-            
+
         return datasets.DatasetInfo(
             description=_DESCRIPTION,
             features=features,
@@ -280,69 +178,59 @@ class KoPICC(datasets.GeneratorBasedBuilder):
             citation=_CITATION,
         )
 
-
     def _split_generators(self, dl_manager) -> List[datasets.SplitGenerator]:
         """Returns SplitGenerators."""
-
-        split_name = self.config.name.split("-")
-        if split_name[0]== "all":
+        name = self.config.name.replace("_" + self.config.schema, "")
+        split_name = name.split("-")
+        if split_name[0] == "all":
             urls = []
             keys = list(_N_SHARDS_PER_SNAPSHOT.keys())
             idx = 0
             if split_name[1] == "raw":
                 idx = 1
-                keys = [ur for ur in list(_N_SHARDS_PER_SNAPSHOT.keys()) if _N_SHARDS_PER_SNAPSHOT[ur].get('raw') is not None]
+                keys = [ur for ur in list(_N_SHARDS_PER_SNAPSHOT.keys()) if _N_SHARDS_PER_SNAPSHOT[ur].get("raw") is not None]
             for m in keys:
-                urls.extend([_URLS[split_name[1]].format(snapshot=m,index=k+idx) for k in range(_N_SHARDS_PER_SNAPSHOT[m].get(split_name[1]))])
+                urls.extend([_URLS[split_name[1]].format(snapshot=m, index=k + idx) for k in range(_N_SHARDS_PER_SNAPSHOT[m].get(split_name[1]))])
         else:
-            urls = [_URLS[split_name[1]].format(snapshot=split_name[0],index=k+1) for k in range(_N_SHARDS_PER_SNAPSHOT[split_name[0]][split_name[1]])]
+            urls = [_URLS[split_name[1]].format(snapshot=split_name[0], index=k + 1) for k in range(_N_SHARDS_PER_SNAPSHOT[split_name[0]][split_name[1]])]
         path = dl_manager.download(urls)
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                gen_kwargs={
-                    "filepath": path,
-                    "split": "train",
-                },
+                gen_kwargs={"filepaths": path, "split": "train", "type": split_name[1]},
             ),
         ]
 
-    def _generate_examples(self, filepaths):
+    def _generate_examples(self, filepaths, split, type):
         """This function returns the examples in the raw (text) form by iterating on all the files."""
         id_ = 0
-        filename, file_extension = os.path.splitext(filepaths)
         for filepath in filepaths:
-            if file_extension == '.zst':
+            if type == "raw":
                 with zstd.open(open(filepath, "rb"), "rt", encoding="utf-8") as f:
                     for line in f:
                         if line:
                             example = json.loads(line)
                             meta = dict()
                             meta["warc_headers"] = example["warc_headers"]
-                            meta["warc_headers"]["warc-identified-content-language"] = example[
-                                "warc_headers"
-                            ].get("warc-identified-content-language")
+                            meta["warc_headers"]["warc-identified-content-language"] = example["warc_headers"].get("warc-identified-content-language")
                             meta["identification"] = example["metadata"]["identification"]
                             meta["annotations"] = example["metadata"]["annotation"]
-                            meta["line_identifications"] = example["metadata"][
-                                "sentence_identifications"
-                            ]
-                            if self.config.schema == "nusa":
-                                yield id_, {"id":str(id_),'text':example['content']}
+                            meta["line_identifications"] = example["metadata"]["sentence_identifications"]
+                            if self.config.schema == "nusantara_ssp":
+                                yield id_, {"id": str(id_), "text": example["content"]}
                                 id_ += 1
                             else:
-                                yield id_, {'text':example['content'],'url':example['warc_headers']['warc-target-uri'],'timestamp':example['warc_headers']['warc-date'],"meta": json.dumps(meta)}
+                                yield id_, {"text": example["content"], "url": example["warc_headers"]["warc-target-uri"], "timestamp": example["warc_headers"]["warc-date"], "meta": json.dumps(meta)}
                                 id_ += 1
             else:
                 with gzip.open(open(filepath, "rb"), "rt", encoding="utf-8") as f:
                     for line in f:
                         if line:
                             example = json.loads(line)
-                            if self.config.schema == "nusa":
-                                yield id_, {"id":str(id_),'text':example['text']}
+                            if self.config.schema == "nusantara_ssp":
+                                yield id_, {"id": str(id_), "text": example["text"]}
                                 id_ += 1
                             else:
-                                yield id_, {'text':example['text'],'url':example['url'],'timestamp':example['timestamp'],'meta': example['meta']}
+                                yield id_, {"text": example["text"], "url": example["url"], "timestamp": example["timestamp"], "meta": example["meta"]}
                                 id_ += 1
-        


### PR DESCRIPTION
accepted config name format:

```
{snapshot}-{dedup format}_{schema}
```

- snapshot : [cc dumps format](https://commoncrawl.org/the-data/get-started/) .  ['all','2021_10', '2021_17', '2021_21', '2021_25', '2021_31', '2021_39', '2021_43', '2021_49', '2022_05', '2022_21', '2022_27']
- dedup_format : type applied deduplication that need to load ['raw','dedup','neardup',neardup_clean']
- schema : nusa or original source ['nusantara_ssp','source']

example:
say if you want to load 2021_31 dumps with neardup format and nusantara source ,the code will look like

```
from datasets import load_dataset
dataset = load_dataset("/data/nusa-crowd/nusantara/nusa_datasets/kopi-cc/kopi_cc.py",name="2021_31-neardup_nusantara_ssp")
```

test unit
```
python -m tests.test_nusantara nusantara/nusa_datasets/kopi-cc/kopi_cc.py --subset_id 2021_31-neardup
```

size file
```
13G     KoPI-CC/2021_10/dedup
11G     KoPI-CC/2021_10/neardup
6.5G    KoPI-CC/2021_10/neardup_clean
5.2G    KoPI-CC/2021_17/dedup
4.4G    KoPI-CC/2021_17/neardup
2.2G    KoPI-CC/2021_17/neardup_clean
5.7G    KoPI-CC/2021_17/raw
4.5G    KoPI-CC/2021_21/dedup
4.0G    KoPI-CC/2021_21/neardup
1.8G    KoPI-CC/2021_21/neardup_clean
4.9G    KoPI-CC/2021_21/raw
3.5G    KoPI-CC/2021_25/dedup
3.0G    KoPI-CC/2021_25/neardup
1.5G    KoPI-CC/2021_25/neardup_clean
3.8G    KoPI-CC/2021_25/raw
5.7G    KoPI-CC/2021_31/dedup
4.9G    KoPI-CC/2021_31/neardup
2.3G    KoPI-CC/2021_31/neardup_clean
6.2G    KoPI-CC/2021_31/raw
5.8G    KoPI-CC/2021_39/dedup
4.7G    KoPI-CC/2021_39/neardup
2.1G    KoPI-CC/2021_39/neardup_clean
6.4G    KoPI-CC/2021_39/raw
6.3G    KoPI-CC/2021_43/dedup
5.0G    KoPI-CC/2021_43/neardup
2.1G    KoPI-CC/2021_43/neardup_clean
6.9G    KoPI-CC/2021_43/raw
4.3G    KoPI-CC/2021_49/dedup
3.6G    KoPI-CC/2021_49/neardup
1.3G    KoPI-CC/2021_49/neardup_clean
6.2G    KoPI-CC/2022_05/dedup
4.8G    KoPI-CC/2022_05/neardup
1.8G    KoPI-CC/2022_05/neardup_clean
7.1G    KoPI-CC/2022_05/raw
5.4G    KoPI-CC/2022_21/dedup
4.4G    KoPI-CC/2022_21/neardup
1.9G    KoPI-CC/2022_21/neardup_clean
6.2G    KoPI-CC/2022_21/raw
5.6G    KoPI-CC/2022_27/dedup
4.4G    KoPI-CC/2022_27/neardup
1.7G    KoPI-CC/2022_27/neardup_clean
6.3G    KoPI-CC/2022_27/raw
```

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
