### PR TITLE
Closes #225 | Bugfix dataset loader for ID-HSD-Nofaaulia

### DIFF
--- a/nusacrowd/nusa_datasets/id_hsd_nofaaulia/id_hsd_nofaaulia.py
+++ b/nusacrowd/nusa_datasets/id_hsd_nofaaulia/id_hsd_nofaaulia.py
@@ -123,7 +123,10 @@ class IdHSDNofaaulia(datasets.GeneratorBasedBuilder):
         # The split follows the implementation below
         # https://github.com/IndoNLP/nusa-crowd/blob/master/nusantara/utils/schemas/pairs.py
         # test_size=0.1, random_state=42
-        x_train, x_test, y_train, y_test = train_test_split(df[features], df[target], test_size=0.1, random_state=42)
+        # tested locally using :
+        # scikit-learn 1.1.2
+        # python 3.10.4
+        x_train, x_test, y_train, y_test = train_test_split(df[features].replace(r'\s+|\\n', ' ', regex=True), df[target], test_size=0.1, random_state=42)
 
         x_train.to_csv(data_files["train"], index=False)
         x_test.to_csv(data_files["test"], index=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ conllu
 openpyxl
 translate-toolkit==3.7.3
 typing_extensions
+scikit-learn==1.1.2
+python==3.10.4


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.
Closes #225 

### Checkbox
- [x] Confirm that this PR is linked to the dataset issue.
- [x] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [x] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [x] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [x] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [x] Confirm dataloader script works with `datasets.load_dataset` function.
- [x] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara --path=nusantara/nusa_datasets/my_dataset/my_dataset.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.

This is the bugfix from the previously closed PR. The changes made are as follows:
1. Added python version and scikit-learn into the requirements.txt
2. Removed '\n' from the input text