### PR TITLE
Multilexnorm bugfix list of word to sentence

### DIFF
--- a/nusacrowd/nusa_datasets/multilexnorm/multilexnorm.py
+++ b/nusacrowd/nusa_datasets/multilexnorm/multilexnorm.py
@@ -142,7 +142,9 @@ class MultiLexNorm(datasets.GeneratorBasedBuilder):
                 tok = line.strip("\n").split("\t")
 
                 if tok == [""] or tok == []:
-                    ex = {"id": str(i), "src_sent": [x[0] for x in curSent], "norm_sent": [x[1] for x in curSent]}
+                    ex = {"id": str(i), 
+                          "src_sent": " ".join([x[0] for x in curSent]), 
+                          "norm_sent": " ".join([x[1] for x in curSent])}
                     yield i, ex
                     i += 1
                     curSent = []
@@ -160,7 +162,11 @@ class MultiLexNorm(datasets.GeneratorBasedBuilder):
                 tok = line.strip("\n").split("\t")
 
                 if tok == [""] or tok == []:
-                    ex = {"id": str(i), "text_1": [x[0] for x in curSent], "text_2": [x[1] for x in curSent], "text_1_name": "src_sent", "text_2_name": "norm_sent"}
+                    ex = {"id": str(i), 
+                          "text_1": " ".join([x[0] for x in curSent]), 
+                          "text_2": " ".join([x[1] for x in curSent]), 
+                          "text_1_name": "src_sent", 
+                          "text_2_name": "norm_sent"}
                     yield i, ex
                     i += 1
                     curSent = []


### PR DESCRIPTION
Please name your PR after the issue it closes. You can use the following line: "Closes #ISSUE-NUMBER" where you replace the ISSUE-NUMBER with the one corresponding to your dataset.

### Checkbox
- [ ] Confirm that this PR is linked to the dataset issue.
- [ ] Create the dataloader script `nusantara/nusa_datasets/my_dataset/my_dataset.py` (please use only lowercase and underscore for dataset naming).
- [ ] Provide values for the `_CITATION`, `_DATASETNAME`, `_DESCRIPTION`, `_HOMEPAGE`, `_LICENSE`, `_URLs`, `_SUPPORTED_TASKS`, `_SOURCE_VERSION`, and `_NUSANTARA_VERSION` variables.
- [ ] Implement `_info()`, `_split_generators()` and `_generate_examples()` in dataloader script.
- [ ] Make sure that the `BUILDER_CONFIGS` class attribute is a list with at least one `NusantaraConfig` for the source schema and one for a nusantara schema.
- [ ] Confirm dataloader script works with `datasets.load_dataset` function.
- [ ] Confirm that your dataloader script passes the test suite run with `python -m tests.test_nusantara nusacrowd/nusa_datasets/multilexnorm/multilexnorm.py`.
- [ ] If my dataset is local, I have provided an output of the unit-tests in the PR (please copy paste). This is OPTIONAL for public datasets, as we can test these without access to the data files.
